### PR TITLE
Reverse order of args in add_filter() so that priority is passed before args count

### DIFF
--- a/steps/addFilter.js
+++ b/steps/addFilter.js
@@ -4,12 +4,12 @@ customSteps.addFilter = function( step ) {
 	// and add them to the add_filter call
 	if ( step.vars.code.match( /function\s*\(/i ) ) {
 		let args = step.vars.code.match( /function\s*\((.*?)\)/i )[1].split( ',' ).length;
-		code += ", " + args;
 		if ( step.vars.priority != 10 ) {
 			code += ", " + step.vars.priority;
 		}
+		code += ", " + args;
 	} else if ( step.vars.priority != 10 ) {
-		code += ", 1, " + step.vars.priority;
+		code += ", " + step.vars.priority + ", 1";
 	}
 	code += " ); ?>";
 	return [


### PR DESCRIPTION
`add_filter( string $hook_name, callable $callback, int $priority = 10, int $accepted_args = 1 ): true`

$priority - 3rd arg
$accepted_args - 4th arg

This PR fixes the order of args.

Output before this PR:

```
{
  "landingPage": "/",
  "steps": [
    {
      "step": "mkdir",
      "path": "wordpress/wp-content/mu-plugins"
    },
    {
      "step": "writeFile",
      "path": "wordpress/wp-content/mu-plugins/addFilter-0.php",
      "data": "<?php require_once 'wordpress/wp-load.php'; add_filter( 'whatever', '__return_false', 1, 12 ); ?>"
    }
  ]
}
```

Output after this PR:

```
{
  "landingPage": "/",
  "steps": [
    {
      "step": "mkdir",
      "path": "wordpress/wp-content/mu-plugins"
    },
    {
      "step": "writeFile",
      "path": "wordpress/wp-content/mu-plugins/addFilter-0.php",
      "data": "<?php require_once 'wordpress/wp-load.php'; add_filter( 'whatever', '__return_false', 12, 1 ); ?>"
    }
  ]
}
```

Additionally, I don't think it needs the `require_once` call in there, is that intentional?