### PR TITLE
Add paste handler for Site Health info

### DIFF
--- a/src/frontend/content-detection.ts
+++ b/src/frontend/content-detection.ts
@@ -3,6 +3,10 @@
  * Functions for detecting different types of content in pasted text
  */
 
+import { isSiteHealthContent, parseSiteHealth, type ParsedSiteHealth } from '../shared/site-health-parser';
+
+export { isSiteHealthContent, parseSiteHealth, type ParsedSiteHealth };
+
 /**
  * Detects the type of URL (plugin, theme, etc.)
  * @param url - The URL to analyze

--- a/src/shared/site-health-parser.ts
+++ b/src/shared/site-health-parser.ts
@@ -1,0 +1,220 @@
+/**
+ * Site Health Parser
+ * Shared parsing utilities for WordPress Site Health info
+ */
+
+export interface PluginInfo {
+	name: string;
+	version: string;
+	author: string | null;
+}
+
+export interface ThemeInfo {
+	name: string | null;
+	version: string | null;
+	path: string | null;
+}
+
+export interface ParsedSiteHealth {
+	theme: string | null;
+	plugins: string[];
+}
+
+/**
+ * Derive a WordPress slug from a plugin or theme name.
+ */
+export function deriveSlugFromName(name: string): string {
+	return name
+		.split(':')[0]
+		.trim()
+		.toLowerCase()
+		.replace(/\s+/g, '-')
+		.replace(/[^a-z0-9-]/g, '')
+		.replace(/-+/g, '-')
+		.replace(/^-|-$/g, '');
+}
+
+/**
+ * Clean site health content by stripping leading backticks.
+ */
+function cleanSiteHealthContent(content: string): string {
+	const trimmed = content.trim();
+	return trimmed.startsWith('`') ? trimmed.slice(1).trim() : trimmed;
+}
+
+/**
+ * Parse site health content into sections.
+ * Returns a map of section name to array of lines.
+ */
+export function parseSections(content: string): Map<string, string[]> {
+	const sections = new Map<string, string[]>();
+	const cleanContent = cleanSiteHealthContent(content);
+	const parts = cleanContent.split(/^###\s+/m);
+
+	for (const part of parts) {
+		if (!part.trim()) continue;
+
+		const lines = part.split('\n');
+		const sectionNameRaw = lines[0].trim().replace(/\s*###\s*$/, '');
+		const sectionName = sectionNameRaw.split(' ')[0];
+
+		sections.set(sectionName, lines.slice(1));
+	}
+
+	return sections;
+}
+
+/**
+ * Parse theme info from wp-active-theme section lines.
+ */
+export function parseThemeFromLines(lines: string[]): ThemeInfo {
+	const info: ThemeInfo = { name: null, version: null, path: null };
+
+	for (const line of lines) {
+		const match = line.match(/^(\w+):\s*(.+)$/);
+		if (!match) continue;
+
+		const key = match[1];
+		const value = match[2].trim();
+
+		if (key === 'name') {
+			const slugMatch = value.match(/\(([^)]+)\)$/);
+			info.name = slugMatch ? slugMatch[1] : value;
+		} else if (key === 'version') {
+			info.version = value;
+		} else if (key === 'theme_path') {
+			const pathMatch = value.match(/\/([^/]+)\/?$/);
+			if (pathMatch) info.path = pathMatch[1];
+		}
+	}
+
+	return info;
+}
+
+/**
+ * Derive theme slug from theme info.
+ */
+export function deriveThemeSlug(info: ThemeInfo): string | null {
+	if (info.name && info.name === info.name.toLowerCase() && !info.name.includes(' ')) {
+		return info.name;
+	}
+	if (info.path) {
+		return info.path;
+	}
+	if (info.name) {
+		return info.name.toLowerCase().replace(/\s+/g, '-');
+	}
+	return null;
+}
+
+/**
+ * Parse a plugin info from a wp-plugins-active line.
+ */
+export function parsePluginFromLine(line: string): PluginInfo | null {
+	if (!line.trim()) return null;
+
+	const versionIndex = line.indexOf('version:');
+	if (versionIndex === -1) return null;
+
+	const pluginNamePart = line.substring(0, versionIndex).trim();
+	const pluginName = pluginNamePart.replace(/\s*:\s*$/, '');
+
+	const versionPart = line.substring(versionIndex + 'version:'.length).trim();
+	const versionMatch = versionPart.match(/^([^,]+)/);
+	if (!versionMatch) return null;
+
+	const pluginVersion = versionMatch[1].trim();
+
+	let pluginAuthor: string | null = null;
+	const authorIndex = line.indexOf('author:');
+	if (authorIndex !== -1) {
+		const authorPart = line.substring(authorIndex + 'author:'.length).trim();
+		const updatesMatch = authorPart.match(/^(.+?)(?:,\s*(?:Updates|Auto-updates))/);
+		pluginAuthor = updatesMatch ? updatesMatch[1].trim() : authorPart.trim();
+	}
+
+	return { name: pluginName, version: pluginVersion, author: pluginAuthor };
+}
+
+/**
+ * Parse plugins from wp-plugins-active section lines.
+ */
+export function parsePluginsFromLines(lines: string[]): PluginInfo[] {
+	const plugins: PluginInfo[] = [];
+	for (const line of lines) {
+		const plugin = parsePluginFromLine(line);
+		if (plugin) plugins.push(plugin);
+	}
+	return plugins;
+}
+
+/**
+ * Check if text is valid Site Health content.
+ */
+export function isSiteHealthContent(text: string): boolean {
+	if (!text || typeof text !== 'string') {
+		return false;
+	}
+
+	const trimmed = text.trim();
+
+	// Site Health info must have ### section markers
+	if (!trimmed.includes('### wp-')) {
+		return false;
+	}
+
+	// Must have at least one of the key sections
+	const hasCore = /### wp-core\s*###?/i.test(trimmed);
+	const hasPlugins = /### wp-plugins-active/i.test(trimmed);
+	const hasTheme = /### wp-active-theme/i.test(trimmed);
+
+	return hasCore || hasPlugins || hasTheme;
+}
+
+/**
+ * Parse Site Health content and extract theme and plugin slugs.
+ */
+export function parseSiteHealth(
+	content: string,
+	options: { installTheme?: boolean; installPlugins?: boolean; installLatest?: boolean } = {}
+): ParsedSiteHealth {
+	const { installTheme = true, installPlugins = true, installLatest = true } = options;
+	const result: ParsedSiteHealth = { theme: null, plugins: [] };
+
+	if (!content.trim()) {
+		return result;
+	}
+
+	const sections = parseSections(content);
+
+	if (installTheme) {
+		const themeLines = sections.get('wp-active-theme');
+		if (themeLines) {
+			const themeInfo = parseThemeFromLines(themeLines);
+			const themeSlug = deriveThemeSlug(themeInfo);
+			if (themeSlug) {
+				result.theme = installLatest || !themeInfo.version
+					? themeSlug
+					: `${themeSlug}@${themeInfo.version}`;
+			}
+		}
+	}
+
+	if (installPlugins) {
+		const pluginLines = sections.get('wp-plugins-active');
+		if (pluginLines) {
+			const pluginInfos = parsePluginsFromLines(pluginLines);
+			for (const plugin of pluginInfos) {
+				const slug = deriveSlugFromName(plugin.name);
+				if (slug) {
+					const pluginSpec = installLatest || !plugin.version
+						? slug
+						: `${slug}@${plugin.version}`;
+					result.plugins.push(pluginSpec);
+				}
+			}
+		}
+	}
+
+	return result;
+}

--- a/steps/siteHealthImport.ts
+++ b/steps/siteHealthImport.ts
@@ -1,5 +1,14 @@
 import type { StepFunction, BlueprintStep, StepResult } from './types.js';
 import type { BlueprintV2Declaration } from '@wp-playground/blueprints';
+import {
+	parseSiteHealth,
+	parseSections,
+	parsePluginsFromLines,
+	parseThemeFromLines,
+	deriveThemeSlug,
+	deriveSlugFromName,
+	type PluginInfo,
+} from '../src/shared/site-health-parser.js';
 
 export interface SiteHealthImportStep extends BlueprintStep {
 	vars?: {
@@ -18,199 +27,6 @@ interface ParsedSiteHealthData {
 	options: Record<string, string>;
 }
 
-interface PluginInfo {
-	name: string;
-	version: string;
-	author: string | null;
-}
-
-interface ThemeInfo {
-	name: string | null;
-	version: string | null;
-	path: string | null;
-}
-
-/**
- * Derive a WordPress slug from a plugin or theme name.
- */
-function deriveSlugFromName(name: string): string {
-	return name
-		.split(':')[0]
-		.trim()
-		.toLowerCase()
-		.replace(/\s+/g, '-')
-		.replace(/[^a-z0-9-]/g, '')
-		.replace(/-+/g, '-')
-		.replace(/^-|-$/g, '');
-}
-
-/**
- * Clean site health content by stripping leading backticks.
- */
-function cleanSiteHealthContent(content: string): string {
-	const trimmed = content.trim();
-	return trimmed.startsWith('`') ? trimmed.slice(1).trim() : trimmed;
-}
-
-/**
- * Parse site health content into sections.
- * Returns a map of section name to array of lines.
- */
-function parseSections(content: string): Map<string, string[]> {
-	const sections = new Map<string, string[]>();
-	const cleanContent = cleanSiteHealthContent(content);
-	const parts = cleanContent.split(/^###\s+/m);
-
-	for (const part of parts) {
-		if (!part.trim()) continue;
-
-		const lines = part.split('\n');
-		const sectionNameRaw = lines[0].trim().replace(/\s*###\s*$/, '');
-		const sectionName = sectionNameRaw.split(' ')[0];
-
-		sections.set(sectionName, lines.slice(1));
-	}
-
-	return sections;
-}
-
-/**
- * Parse theme info from wp-active-theme section lines.
- */
-function parseThemeFromLines(lines: string[]): ThemeInfo {
-	const info: ThemeInfo = { name: null, version: null, path: null };
-
-	for (const line of lines) {
-		const match = line.match(/^(\w+):\s*(.+)$/);
-		if (!match) continue;
-
-		const key = match[1];
-		const value = match[2].trim();
-
-		if (key === 'name') {
-			const slugMatch = value.match(/\(([^)]+)\)$/);
-			info.name = slugMatch ? slugMatch[1] : value;
-		} else if (key === 'version') {
-			info.version = value;
-		} else if (key === 'theme_path') {
-			const pathMatch = value.match(/\/([^/]+)\/?$/);
-			if (pathMatch) info.path = pathMatch[1];
-		}
-	}
-
-	return info;
-}
-
-/**
- * Derive theme slug from theme info.
- */
-function deriveThemeSlug(info: ThemeInfo): string | null {
-	if (info.name && info.name === info.name.toLowerCase() && !info.name.includes(' ')) {
-		return info.name;
-	}
-	if (info.path) {
-		return info.path;
-	}
-	if (info.name) {
-		return info.name.toLowerCase().replace(/\s+/g, '-');
-	}
-	return null;
-}
-
-/**
- * Parse a plugin info from a wp-plugins-active line.
- */
-function parsePluginFromLine(line: string): PluginInfo | null {
-	if (!line.trim()) return null;
-
-	const versionIndex = line.indexOf('version:');
-	if (versionIndex === -1) return null;
-
-	const pluginNamePart = line.substring(0, versionIndex).trim();
-	const pluginName = pluginNamePart.replace(/\s*:\s*$/, '');
-
-	const versionPart = line.substring(versionIndex + 'version:'.length).trim();
-	const versionMatch = versionPart.match(/^([^,]+)/);
-	if (!versionMatch) return null;
-
-	const pluginVersion = versionMatch[1].trim();
-
-	let pluginAuthor: string | null = null;
-	const authorIndex = line.indexOf('author:');
-	if (authorIndex !== -1) {
-		const authorPart = line.substring(authorIndex + 'author:'.length).trim();
-		const updatesMatch = authorPart.match(/^(.+?)(?:,\s*(?:Updates|Auto-updates))/);
-		pluginAuthor = updatesMatch ? updatesMatch[1].trim() : authorPart.trim();
-	}
-
-	return { name: pluginName, version: pluginVersion, author: pluginAuthor };
-}
-
-/**
- * Parse plugins from wp-plugins-active section lines.
- */
-function parsePluginsFromLines(lines: string[]): PluginInfo[] {
-	const plugins: PluginInfo[] = [];
-	for (const line of lines) {
-		const plugin = parsePluginFromLine(line);
-		if (plugin) plugins.push(plugin);
-	}
-	return plugins;
-}
-
-interface SyncParsedData {
-	theme: string | null;
-	plugins: string[];
-}
-
-/**
- * Synchronous parsing of site health content for theme and plugin slugs.
- * Used by toV1() and toV2() which cannot be async.
- */
-function parseSiteHealthSync(
-	content: string,
-	options: { installTheme: boolean; installPlugins: boolean; installLatest: boolean }
-): SyncParsedData {
-	const result: SyncParsedData = { theme: null, plugins: [] };
-
-	if (!content.trim()) {
-		return result;
-	}
-
-	const sections = parseSections(content);
-
-	if (options.installTheme) {
-		const themeLines = sections.get('wp-active-theme');
-		if (themeLines) {
-			const themeInfo = parseThemeFromLines(themeLines);
-			const themeSlug = deriveThemeSlug(themeInfo);
-			if (themeSlug) {
-				result.theme = options.installLatest || !themeInfo.version
-					? themeSlug
-					: `${themeSlug}@${themeInfo.version}`;
-			}
-		}
-	}
-
-	if (options.installPlugins) {
-		const pluginLines = sections.get('wp-plugins-active');
-		if (pluginLines) {
-			const pluginInfos = parsePluginsFromLines(pluginLines);
-			for (const plugin of pluginInfos) {
-				const slug = deriveSlugFromName(plugin.name);
-				if (slug) {
-					const pluginSpec = options.installLatest || !plugin.version
-						? slug
-						: `${slug}@${plugin.version}`;
-					result.plugins.push(pluginSpec);
-				}
-			}
-		}
-	}
-
-	return result;
-}
-
 /**
  * Query WordPress.org plugins update-check API to map plugin names to slugs.
  * Uses the update-check API which accepts plugin metadata (Name, Author, Version)
@@ -224,7 +40,6 @@ async function mapPluginNamesToSlugs(plugins: PluginInfo[]): Promise<Map<string,
 	}
 
 	try {
-		// Build request body for update-check API
 		const pluginsData: Record<string, { Name: string; Version: string; Author?: string }> = {};
 		const activePlugins: string[] = [];
 
@@ -276,8 +91,6 @@ async function mapPluginNamesToSlugs(plugins: PluginInfo[]): Promise<Map<string,
 		console.warn('Warning: Could not query WordPress.org plugins update-check API:', error);
 	}
 
-	// For plugins not mapped by the update-check API, derive slugs optimistically
-	// and verify they exist on WordPress.org before including them
 	const unmappedPlugins = plugins.filter((plugin) => !nameToSlug.has(plugin.name));
 
 	if (unmappedPlugins.length > 0) {
@@ -285,7 +98,6 @@ async function mapPluginNamesToSlugs(plugins: PluginInfo[]): Promise<Map<string,
 			.map((plugin) => ({ plugin, slug: deriveSlugFromName(plugin.name) }))
 			.filter(({ slug }) => slug);
 
-		// Verify each candidate slug exists on WordPress.org
 		const verificationPromises = candidateSlugs.map(async ({ plugin, slug }) => {
 			try {
 				const response = await fetch(
@@ -299,7 +111,6 @@ async function mapPluginNamesToSlugs(plugins: PluginInfo[]): Promise<Map<string,
 
 				if (response.ok) {
 					const data = await response.json();
-					// The API returns an object with 'error' if the plugin doesn't exist
 					if (data && !data.error && data.slug) {
 						return { plugin, slug: data.slug, verified: true };
 					}
@@ -339,7 +150,6 @@ async function parseSiteHealthContent(content: string): Promise<ParsedSiteHealth
 
 	const sections = parseSections(content);
 
-	// Parse wp-core section
 	const coreLines = sections.get('wp-core');
 	if (coreLines) {
 		for (const line of coreLines) {
@@ -361,7 +171,6 @@ async function parseSiteHealthContent(content: string): Promise<ParsedSiteHealth
 		}
 	}
 
-	// Parse wp-server section
 	const serverLines = sections.get('wp-server');
 	if (serverLines) {
 		for (const line of serverLines) {
@@ -376,7 +185,6 @@ async function parseSiteHealthContent(content: string): Promise<ParsedSiteHealth
 		}
 	}
 
-	// Parse wp-active-theme section
 	const themeLines = sections.get('wp-active-theme');
 	if (themeLines) {
 		const themeInfo = parseThemeFromLines(themeLines);
@@ -386,7 +194,6 @@ async function parseSiteHealthContent(content: string): Promise<ParsedSiteHealth
 		}
 	}
 
-	// Parse wp-plugins-active section
 	const pluginLines = sections.get('wp-plugins-active');
 	if (pluginLines) {
 		const pluginInfos = parsePluginsFromLines(pluginLines);
@@ -415,7 +222,7 @@ export const siteHealthImport: StepFunction<SiteHealthImportStep> = (step: SiteH
 
 	return {
 		toV1() {
-			const { theme, plugins } = parseSiteHealthSync(siteHealthContent, {
+			const { theme, plugins } = parseSiteHealth(siteHealthContent, {
 				installTheme,
 				installPlugins,
 				installLatest,
@@ -459,7 +266,7 @@ export const siteHealthImport: StepFunction<SiteHealthImportStep> = (step: SiteH
 		},
 
 		toV2(): BlueprintV2Declaration {
-			const { theme, plugins } = parseSiteHealthSync(siteHealthContent, {
+			const { theme, plugins } = parseSiteHealth(siteHealthContent, {
 				installTheme,
 				installPlugins,
 				installLatest,
@@ -509,5 +316,4 @@ siteHealthImport.vars = [
 	},
 ];
 
-// Export the async parsing function for potential use in other contexts
 export { parseSiteHealthContent, mapPluginNamesToSlugs };


### PR DESCRIPTION
Takes https://github.com/akirk/playground-step-library/pull/19 further. This allows you to have a site health report in your clipboard and just paste it while on the step library.

## Screenshot

<img width="1492" height="941" alt="Screenshot 2026-01-26 at 13 24 28" src="https://github.com/user-attachments/assets/b3af1c83-008d-422a-939d-bfb2a452a7e8" />


## Summary

- Add shared `site-health-parser` module with reusable parsing functions
- Update `siteHealthImport` step to use the shared parser (reduces duplication)
- Add Site Health detection to `content-detection.ts`
- Add paste handler that creates individual `installPlugin`/`installTheme` steps

## How it works

When pasting Site Health info (from WordPress Tools → Site Health → Info → Copy site info), the handler:
1. Detects Site Health content by looking for `### wp-` section markers
2. Parses the theme from `### wp-active-theme` section
3. Parses plugins from `### wp-plugins-active` section
4. Adds individual steps for each plugin and theme found

The benefit of creating individual steps (vs a single `siteHealthImport` step) is that you can review and modify the plugins and theme before running the blueprint.

## Test plan

- [ ] Paste Site Health info from a WordPress site
- [ ] Verify theme is added as an `installTheme` step
- [ ] Verify plugins are added as individual `installPlugin` steps
- [ ] Verify toast message shows correct count

cc @adamziel @tellyworth