### PR TITLE
Fix step click insertion inside categories

### DIFF
--- a/src/frontend/event-handlers-controller.ts
+++ b/src/frontend/event-handlers-controller.ts
@@ -156,7 +156,7 @@ export class EventHandlersController {
 		}
 
 		// Handle step insertion from library
-		if (target.closest('.step') && target.closest('#step-library') && !target.closest('details')) {
+		if (target.closest('.step') && target.closest('#step-library') && !target.closest('.step details')) {
 			this.deps.insertStep(event.target!);
 			return;
 		}


### PR DESCRIPTION
## Summary
- Broken by #23 
- Restore click-to-add behavior for steps inside grouped category `<details>` wrappers
- Keep ignoring clicks on `<details>` controls that are inside individual steps

## Testing
- npm test
- npx tsc --noEmit