### PR TITLE
Improve mobile builder UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,6 +37,7 @@
 			const mobileButton = document.getElementById('mobile-show-steps');
 			const stepLibraryHolder = document.getElementById('step-library-holder');
 			const filterHolder = document.getElementById('filter-holder');
+			const blueprintSteps = document.getElementById('blueprint-steps');
 
 			// Toggle step library
 			if (mobileButton) {
@@ -54,6 +55,50 @@
 					}
 				});
 			}
+
+			const compiledHolder = document.getElementById('blueprint-compiled-holder');
+			const compiledToggle = document.getElementById('toggle-compiled-panel');
+			const compiledStats = document.getElementById('blueprint-collapsed-stats');
+
+			function updateCompiledStats() {
+				if (!blueprintSteps || !compiledStats) {
+					return;
+				}
+
+				const stepCount = blueprintSteps.querySelectorAll(':scope > .step').length;
+				compiledStats.textContent = stepCount === 1 ? '1 step' : `${stepCount} steps`;
+			}
+
+			function setCompiledCollapsed(collapsed) {
+				if (!compiledHolder || !compiledToggle) {
+					return;
+				}
+
+				updateCompiledStats();
+				compiledHolder.classList.toggle('mobile-collapsed', collapsed);
+				compiledToggle.setAttribute('aria-expanded', collapsed ? 'false' : 'true');
+				compiledToggle.textContent = collapsed ? 'Show' : 'Hide';
+			}
+
+			if (compiledHolder && compiledToggle) {
+				updateCompiledStats();
+
+				if (blueprintSteps) {
+					new MutationObserver(updateCompiledStats).observe(blueprintSteps, { childList: true });
+				}
+
+				setCompiledCollapsed(window.innerWidth <= 734);
+
+				compiledToggle.addEventListener('click', function() {
+					setCompiledCollapsed(!compiledHolder.classList.contains('mobile-collapsed'));
+				});
+
+				window.addEventListener('resize', function() {
+					if (window.innerWidth > 734) {
+						setCompiledCollapsed(false);
+					}
+				});
+			}
 		});
 	</script>
 </head>
@@ -67,8 +112,11 @@
 				<select id="examples">
 					<option>Examples</option>
 				</select>
-				<span id="options-wrapper">
-					<button id="toggle-further-options"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><circle cx="12" cy="12" r="3" stroke="currentColor" stroke-width="1.5"/><path d="M13.7654 2.15224C13.3978 2 12.9319 2 12 2C11.0681 2 10.6022 2 10.2346 2.15224C9.74457 2.35523 9.35522 2.74458 9.15223 3.23463C9.05957 3.45834 9.0233 3.7185 9.00911 4.09799C8.98826 4.65568 8.70226 5.17189 8.21894 5.45093C7.73564 5.72996 7.14559 5.71954 6.65219 5.45876C6.31645 5.2813 6.07301 5.18262 5.83294 5.15102C5.30704 5.08178 4.77518 5.22429 4.35436 5.5472C4.03874 5.78938 3.80577 6.1929 3.33983 6.99993C2.87389 7.80697 2.64092 8.21048 2.58899 8.60491C2.51976 9.1308 2.66227 9.66266 2.98518 10.0835C3.13256 10.2756 3.3397 10.437 3.66119 10.639C4.1338 10.936 4.43789 11.4419 4.43786 12C4.43783 12.5581 4.13375 13.0639 3.66118 13.3608C3.33965 13.5629 3.13248 13.7244 2.98508 13.9165C2.66217 14.3373 2.51966 14.8691 2.5889 15.395C2.64082 15.7894 2.87379 16.193 3.33973 17C3.80568 17.807 4.03865 18.2106 4.35426 18.4527C4.77508 18.7756 5.30694 18.9181 5.83284 18.8489C6.07289 18.8173 6.31632 18.7186 6.65204 18.5412C7.14547 18.2804 7.73556 18.27 8.2189 18.549C8.70224 18.8281 8.98826 19.3443 9.00911 19.9021C9.02331 20.2815 9.05957 20.5417 9.15223 20.7654C9.35522 21.2554 9.74457 21.6448 10.2346 21.8478C10.6022 22 11.0681 22 12 22C12.9319 22 13.3978 22 13.7654 21.8478C14.2554 21.6448 14.6448 21.2554 14.8477 20.7654C14.9404 20.5417 14.9767 20.2815 14.9909 19.902C15.0117 19.3443 15.2977 18.8281 15.781 18.549C16.2643 18.2699 16.8544 18.2804 17.3479 18.5412C17.6836 18.7186 17.927 18.8172 18.167 18.8488C18.6929 18.9181 19.2248 18.7756 19.6456 18.4527C19.9612 18.2105 20.1942 17.807 20.6601 16.9999C21.1261 16.1929 21.3591 15.7894 21.411 15.395C21.4802 14.8691 21.3377 14.3372 21.0148 13.9164C20.8674 13.7243 20.6602 13.5628 20.3387 13.3608C19.8662 13.0639 19.5621 12.558 19.5621 11.9999C19.5621 11.4418 19.8662 10.9361 20.3387 10.6392C20.6603 10.4371 20.8675 10.2757 21.0149 10.0835C21.3378 9.66273 21.4803 9.13087 21.4111 8.60497C21.3592 8.21055 21.1262 7.80703 20.6602 7C20.1943 6.19297 19.9613 5.78945 19.6457 5.54727C19.2249 5.22436 18.693 5.08185 18.1671 5.15109C17.9271 5.18269 17.6837 5.28136 17.3479 5.4588C16.8545 5.71959 16.2644 5.73002 15.7811 5.45096C15.2977 5.17191 15.0117 4.65566 14.9909 4.09794C14.9767 3.71848 14.9404 3.45833 14.8477 3.23463C14.6448 2.74458 14.2554 2.35523 13.7654 2.15224Z" stroke="currentColor" stroke-width="1.5"/></svg> Blueprint Settings</button>
+				<span id="header-overflow-dropdown" class="more-options-dropdown header-overflow-dropdown">
+					<button class="more-options-button header-overflow-button" title="More options" aria-label="More options"><svg width="6" height="16" viewBox="0 0 4 24" fill="none" xmlns="http://www.w3.org/2000/svg"><circle cx="2" cy="5" r="2" fill="currentColor"/><circle cx="2" cy="12" r="2" fill="currentColor"/><circle cx="2" cy="19" r="2" fill="currentColor"/></svg></button>
+					<span id="header-overflow-menu" class="more-options-menu header-overflow-menu">
+					<span id="options-wrapper">
+						<button id="toggle-further-options"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><circle cx="12" cy="12" r="3" stroke="currentColor" stroke-width="1.5"/><path d="M13.7654 2.15224C13.3978 2 12.9319 2 12 2C11.0681 2 10.6022 2 10.2346 2.15224C9.74457 2.35523 9.35522 2.74458 9.15223 3.23463C9.05957 3.45834 9.0233 3.7185 9.00911 4.09799C8.98826 4.65568 8.70226 5.17189 8.21894 5.45093C7.73564 5.72996 7.14559 5.71954 6.65219 5.45876C6.31645 5.2813 6.07301 5.18262 5.83294 5.15102C5.30704 5.08178 4.77518 5.22429 4.35436 5.5472C4.03874 5.78938 3.80577 6.1929 3.33983 6.99993C2.87389 7.80697 2.64092 8.21048 2.58899 8.60491C2.51976 9.1308 2.66227 9.66266 2.98518 10.0835C3.13256 10.2756 3.3397 10.437 3.66119 10.639C4.1338 10.936 4.43789 11.4419 4.43786 12C4.43783 12.5581 4.13375 13.0639 3.66118 13.3608C3.33965 13.5629 3.13248 13.7244 2.98508 13.9165C2.66217 14.3373 2.51966 14.8691 2.5889 15.395C2.64082 15.7894 2.87379 16.193 3.33973 17C3.80568 17.807 4.03865 18.2106 4.35426 18.4527C4.77508 18.7756 5.30694 18.9181 5.83284 18.8489C6.07289 18.8173 6.31632 18.7186 6.65204 18.5412C7.14547 18.2804 7.73556 18.27 8.2189 18.549C8.70224 18.8281 8.98826 19.3443 9.00911 19.9021C9.02331 20.2815 9.05957 20.5417 9.15223 20.7654C9.35522 21.2554 9.74457 21.6448 10.2346 21.8478C10.6022 22 11.0681 22 12 22C12.9319 22 13.3978 22 13.7654 21.8478C14.2554 21.6448 14.6448 21.2554 14.8477 20.7654C14.9404 20.5417 14.9767 20.2815 14.9909 19.902C15.0117 19.3443 15.2977 18.8281 15.781 18.549C16.2643 18.2699 16.8544 18.2804 17.3479 18.5412C17.6836 18.7186 17.927 18.8172 18.167 18.8488C18.6929 18.9181 19.2248 18.7756 19.6456 18.4527C19.9612 18.2105 20.1942 17.807 20.6601 16.9999C21.1261 16.1929 21.3591 15.7894 21.411 15.395C21.4802 14.8691 21.3377 14.3372 21.0148 13.9164C20.8674 13.7243 20.6602 13.5628 20.3387 13.3608C19.8662 13.0639 19.5621 12.558 19.5621 11.9999C19.5621 11.4418 19.8662 10.9361 20.3387 10.6392C20.6603 10.4371 20.8675 10.2757 21.0149 10.0835C21.3378 9.66273 21.4803 9.13087 21.4111 8.60497C21.3592 8.21055 21.1262 7.80703 20.6602 7C20.1943 6.19297 19.9613 5.78945 19.6457 5.54727C19.2249 5.22436 18.693 5.08185 18.1671 5.15109C17.9271 5.18269 17.6837 5.28136 17.3479 5.4588C16.8545 5.71959 16.2644 5.73002 15.7811 5.45096C15.2977 5.17191 15.0117 4.65566 14.9909 4.09794C14.9767 3.71848 14.9404 3.45833 14.8477 3.23463C14.6448 2.74458 14.2554 2.35523 13.7654 2.15224Z" stroke="currentColor" stroke-width="1.5"/></svg> Blueprint Settings</button>
 					<details id="further-options">
 						<summary style="display:none;">Further Options</summary>
 						<div>
@@ -130,16 +178,18 @@
 				<select id="preview-mode">
 					<option value="">Live-Preview Off</option>
 					<option value="bottom">Preview Bottom</option>
-					<option value="right">Preview Right</option>
-				</select>
-				<button id="wizard-mode-toggle"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M15 9H13M13.6213 4.37866L11.5 6.49998M9 5V3M6.50004 6.50001L4.37872 4.37869M5 9H3M6.50004 11.5L4.37872 13.6214M9 15V13M20 20L12 12" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg> Wizard Mode</button>
-			</span>
+						<option value="right">Preview Right</option>
+					</select>
+					<button id="wizard-mode-toggle"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M15 9H13M13.6213 4.37866L11.5 6.49998M9 5V3M6.50004 6.50001L4.37872 4.37869M5 9H3M6.50004 11.5L4.37872 13.6214M9 15V13M20 20L12 12" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg> Wizard Mode</button>
+					</span>
+				</span>
+				</span>
 		</div>
-		<p>Drag or click the steps to create a <a
+		<p><span class="desktop-instructions">Drag or click the steps to create a <a
 			href="https://wordpress.github.io/wordpress-playground/blueprints/"
 			target="_blank">blueprint</a> for <a href="https://wordpress.github.io/wordpress-playground/"
 			target="_blank">WordPress Playground</a>. You can <a
-			href="https://github.com/akirk/playground-step-library/#contributing">create and submit your own steps!</a></p>
+			href="https://github.com/akirk/playground-step-library/#contributing">create and submit your own steps!</a></span><span class="mobile-instructions">Add steps to build your custom WordPress Playground.</span></p>
 	</header>
 	<div id="split-view-wrapper">
 		<div id="blueprint-builder">
@@ -159,9 +209,13 @@
 			<div class="arrow">→</div>
 			<div id="blueprint-compiled-holder">
 				<div id="blueprint-compiled-header">
-					<div>Transformed Blueprint</div>
-					<button id="history-button"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M19 1H8.99C7.89 1 7 1.9 7 3H17C18.1 3 19 3.9 19 5V18L21 19V3C21 1.9 20.1 1 19 1ZM15 7V19.97L10 17.82L5 19.97V7H15ZM5 5H15C16.1 5 17 5.9 17 7V23L10 20L3 23V7C3 5.9 3.9 5 5 5Z" fill="currentColor"/></svg> Mine</button>
+					<div>Blueprint</div>
+					<div class="compiled-header-actions">
+						<button id="toggle-compiled-panel" class="mobile-only" aria-expanded="false" aria-controls="blueprint-compiled-wrapper">Show</button>
+						<button id="history-button"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M19 1H8.99C7.89 1 7 1.9 7 3H17C18.1 3 19 3.9 19 5V18L21 19V3C21 1.9 20.1 1 19 1ZM15 7V19.97L10 17.82L5 19.97V7H15ZM5 5H15C16.1 5 17 5.9 17 7V23L10 20L3 23V7C3 5.9 3.9 5 5 5Z" fill="currentColor"/></svg> Mine</button>
+					</div>
 				</div>
+				<div id="blueprint-collapsed-stats" aria-live="polite">0 steps</div>
 				<div id="blueprint-compiled-wrapper">
 					<textarea id="blueprint-compiled"></textarea>
 					<div id="blueprint-status" class="ace-status-bar"></div>

--- a/src/frontend/history-controller.ts
+++ b/src/frontend/history-controller.ts
@@ -58,13 +58,20 @@ export class HistoryController {
 			});
 		}
 
-		// Close button
-		const closeBtn = document.getElementById('history-close');
-		if (closeBtn) {
-			closeBtn.addEventListener('click', () => {
-				this.closeHistoryModal();
-			});
-		}
+			// Close button
+			const closeBtn = document.getElementById('history-close');
+			if (closeBtn) {
+				closeBtn.addEventListener('click', () => {
+					this.closeHistoryModal();
+				});
+			}
+
+			const mobileBackBtn = document.getElementById('history-mobile-back-btn');
+			if (mobileBackBtn) {
+				mobileBackBtn.addEventListener('click', () => {
+					this.hideMobileDetailPane();
+				});
+			}
 
 		// Save current button
 		const saveCurrentBtn = document.getElementById('history-save-current-btn');
@@ -114,25 +121,41 @@ export class HistoryController {
 	/**
 	 * Open the My Blueprints modal
 	 */
-	openHistoryModal(): void {
-		const modal = document.getElementById('history-modal') as HTMLDialogElement;
-		if (modal) {
-			modal.showModal();
-			this.renderHistoryList();
-			this.updateHistoryButtonVisibility();
+		openHistoryModal(): void {
+			const modal = document.getElementById('history-modal') as HTMLDialogElement;
+			if (modal) {
+				modal.showModal();
+				this.hideMobileDetailPane();
+				this.renderHistoryList();
+				this.updateHistoryButtonVisibility();
+			}
 		}
-	}
 
 	/**
 	 * Close the My Blueprints modal
 	 */
-	closeHistoryModal(): void {
-		const modal = document.getElementById('history-modal') as HTMLDialogElement;
-		if (modal) {
-			modal.close();
-			cleanupHistoryBlueprintAceEditor();
+		closeHistoryModal(): void {
+			const modal = document.getElementById('history-modal') as HTMLDialogElement;
+			if (modal) {
+				modal.close();
+				this.hideMobileDetailPane();
+				cleanupHistoryBlueprintAceEditor();
+			}
 		}
-	}
+
+		private showMobileDetailPane(): void {
+			const detailColumn = document.getElementById('history-detail-column');
+			if (detailColumn) {
+				detailColumn.classList.add('mobile-visible');
+			}
+		}
+
+		private hideMobileDetailPane(): void {
+			const detailColumn = document.getElementById('history-detail-column');
+			if (detailColumn) {
+				detailColumn.classList.remove('mobile-visible');
+			}
+		}
 
 	/**
 	 * Add current blueprint to history
@@ -383,9 +406,10 @@ export class HistoryController {
 			}
 		}
 
-		// Setup action buttons
-		this.setupDetailActions(entryId);
-	}
+			// Setup action buttons
+			this.setupDetailActions(entryId);
+			this.showMobileDetailPane();
+		}
 
 	/**
 	 * Restore the blueprint detail view structure
@@ -697,13 +721,25 @@ export class HistoryController {
 	/**
 	 * Check if blueprint is already saved
 	 */
-	isBlueprintAlreadySaved(): boolean {
-		return this.deps.isBlueprintAlreadySaved();
-	}
+		isBlueprintAlreadySaved(): boolean {
+			return this.deps.isBlueprintAlreadySaved();
+		}
 
-	/**
-	 * Show personal step detail view
-	 */
+		private formatStoredParameterValue(value: any): string {
+			if (Array.isArray(value)) {
+				return value.map((item) => this.formatStoredParameterValue(item)).join(', ');
+			}
+
+			if (value && typeof value === 'object') {
+				return JSON.stringify(value, null, 2);
+			}
+
+			return String(value ?? '');
+		}
+
+		/**
+		 * Show personal step detail view
+		 */
 	showPersonalStepDetail(stepName: string, stepDefinition: any): void {
 		const detailContent = document.getElementById('history-detail-content');
 		const detailEmpty = document.getElementById('history-detail-empty');
@@ -746,29 +782,33 @@ export class HistoryController {
 			detailContent.appendChild(description);
 		}
 
-		const varsSection = document.createElement('div');
-		varsSection.className = 'history-detail-section';
-		const varsHeader = document.createElement('h4');
-		varsHeader.textContent = 'Variables';
-		varsSection.appendChild(varsHeader);
+			const varsSection = document.createElement('div');
+			varsSection.className = 'history-detail-section';
+			const varsHeader = document.createElement('h4');
+			varsHeader.textContent = 'Stored Parameters';
+			varsSection.appendChild(varsHeader);
 
-		if (stepDefinition.vars && stepDefinition.vars.length > 0) {
-			const varsList = document.createElement('ul');
-			varsList.className = 'personal-step-vars-list';
-			stepDefinition.vars.forEach((v: any) => {
-				const li = document.createElement('li');
-				li.textContent = `${v.name}${v.required ? ' (required)' : ''}`;
-				if (v.default !== undefined && v.default !== '') {
-					li.textContent += ` - default: ${v.default}`;
-				}
-				varsList.appendChild(li);
-			});
-			varsSection.appendChild(varsList);
-		} else {
-			const noVars = document.createElement('p');
-			noVars.textContent = 'No variables';
-			varsSection.appendChild(noVars);
-		}
+			const storedVars = (stepDefinition.vars || []).filter((v: any) => typeof v.setValue !== 'undefined');
+
+			if (storedVars.length > 0) {
+				const varsList = document.createElement('ul');
+				varsList.className = 'personal-step-vars-list';
+				storedVars.forEach((v: any) => {
+					const li = document.createElement('li');
+					const name = document.createElement('strong');
+					name.textContent = v.name;
+					const value = document.createElement('code');
+					value.textContent = this.formatStoredParameterValue(v.setValue);
+					li.appendChild(name);
+					li.appendChild(value);
+					varsList.appendChild(li);
+				});
+				varsSection.appendChild(varsList);
+			} else {
+				const noVars = document.createElement('p');
+				noVars.textContent = 'No stored parameters';
+				varsSection.appendChild(noVars);
+			}
 
 		detailContent.appendChild(varsSection);
 
@@ -785,11 +825,13 @@ export class HistoryController {
 				this.renderHistoryList();
 				detailContent.style.display = 'none';
 				detailEmpty.style.display = 'block';
+				this.hideMobileDetailPane();
 				toastService.showInBlueprintsDialog(`Deleted "${stepName}"`);
 			}
 		});
 
 		actions.appendChild(deleteBtn);
 		detailContent.appendChild(actions);
+		this.showMobileDetailPane();
 	}
 }

--- a/src/frontend/main.ts
+++ b/src/frontend/main.ts
@@ -130,6 +130,73 @@ addEventListener('DOMContentLoaded', function () {
 		myStepNameEl.value = '';
 	}
 
+	function normalizeStepValue(value: unknown): string {
+		return String(value ?? '');
+	}
+
+	function getInputValue(input: HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement): string {
+		if (input instanceof HTMLInputElement && input.type === 'checkbox') {
+			return normalizeStepValue(input.checked);
+		}
+
+		return normalizeStepValue(input.value);
+	}
+
+	function getDefaultValues(stepDefinition: StepDefinition, fieldName: string): string[] {
+		if (fieldName === 'count') {
+			return [normalizeStepValue(stepDefinition.count)];
+		}
+
+		const variable = stepDefinition.vars?.find((stepVariable) => stepVariable.name === fieldName);
+		if (!variable) {
+			return [''];
+		}
+
+		if (typeof variable.setValue !== 'undefined') {
+			return (Array.isArray(variable.setValue) ? variable.setValue : [variable.setValue]).map(normalizeStepValue);
+		}
+
+		if (variable.type === 'select') {
+			return [normalizeStepValue(variable.samples?.[0] ?? variable.options?.[0] ?? '')];
+		}
+
+		return [normalizeStepValue(variable.samples?.[0] ?? '')];
+	}
+
+	function isStepModifiedFromDefault(stepElement: HTMLElement): boolean {
+		if (stepElement.classList.contains('mine')) {
+			return false;
+		}
+
+		const stepName = stepElement.dataset.step;
+		const stepDefinition = stepName ? customSteps[stepName] : undefined;
+		if (!stepDefinition) {
+			return false;
+		}
+
+		const fields = Array.from(stepElement.querySelectorAll('input,select,textarea')) as (HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement)[];
+		const fieldNames = Array.from(new Set(fields.map((field) => field.name).filter(Boolean)));
+
+		return fieldNames.some((fieldName) => {
+			const currentValues = fields.filter((field) => field.name === fieldName).map(getInputValue);
+			const defaultValues = getDefaultValues(stepDefinition, fieldName);
+
+			if (currentValues.length !== defaultValues.length) {
+				return true;
+			}
+
+			return currentValues.some((currentValue, index) => currentValue !== defaultValues[index]);
+		});
+	}
+
+	function updateSaveStepButtonVisibility() {
+		blueprintSteps.querySelectorAll('.step').forEach((stepElement) => {
+			if (stepElement instanceof HTMLElement) {
+				stepElement.classList.toggle('show-save-step', isStepModifiedFromDefault(stepElement));
+			}
+		});
+	}
+
 	document.addEventListener('dragstart', (event) => {
 		if (!(event.target instanceof Element)) return;
 
@@ -208,9 +275,13 @@ addEventListener('DOMContentLoaded', function () {
 		}
 		// Only handle inputs/textareas in blueprint-steps
 		if (target.closest('#blueprint-steps') && (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA')) {
+			updateSaveStepButtonVisibility();
 			debouncedBlueprintUpdate();
 		}
 	});
+
+	blueprintSteps.addEventListener('change', updateSaveStepButtonVisibility);
+	new MutationObserver(updateSaveStepButtonVisibility).observe(blueprintSteps, { childList: true, subtree: true });
 
 	document.addEventListener('keyup', (event) => {
 		if (event.ctrlKey || event.altKey || event.metaKey) {
@@ -561,6 +632,7 @@ addEventListener('DOMContentLoaded', function () {
 	blueprintEventBus.on('blueprint:updated', () => {
 		loadCombinedExamples();
 		updateMenuItemVisibility();
+		updateSaveStepButtonVisibility();
 	});
 
 	function updateMenuItemVisibility() {
@@ -773,6 +845,11 @@ addEventListener('DOMContentLoaded', function () {
 	const mainDropdown = document.getElementById('more-options-dropdown');
 	if (mainDropdown) {
 		urlController.initMoreOptionsDropdown(mainDropdown);
+	}
+
+	const headerDropdown = document.getElementById('header-overflow-dropdown');
+	if (headerDropdown) {
+		urlController.initMoreOptionsDropdown(headerDropdown);
 	}
 
 	const moreOptionsMenu = document.getElementById( 'more-options-menu' );

--- a/src/styles/_blueprint.css
+++ b/src/styles/_blueprint.css
@@ -39,6 +39,17 @@ body.blueprint-drop-active {
 	margin-bottom: var(--spacing-2);
 }
 
+.compiled-header-actions {
+	display: flex;
+	align-items: center;
+	gap: var(--spacing-2);
+	margin-left: auto;
+}
+
+#blueprint-collapsed-stats {
+	display: none;
+}
+
 /* Blueprint Compiled Wrapper */
 #blueprint-compiled-wrapper {
 	position: relative;

--- a/src/styles/_components.css
+++ b/src/styles/_components.css
@@ -268,6 +268,10 @@
 	display: none;
 }
 
+.mobile-instructions {
+	display: none;
+}
+
 #mobile-show-steps {
 	margin-top: var(--spacing-4);
 }
@@ -278,6 +282,118 @@
 	gap: var(--spacing-3);
 	align-items: center;
 	flex-wrap: wrap;
+}
+
+.header-overflow-dropdown,
+.header-overflow-menu {
+	display: contents;
+}
+
+.header-overflow-button {
+	display: none !important;
+}
+
+.header-overflow-menu > #options-wrapper > #toggle-further-options,
+.header-overflow-menu > #wizard-mode-toggle {
+	display: inline-flex;
+	width: auto;
+	border: 1px solid var(--button-border);
+	background-color: var(--button-background);
+	color: var(--text-color);
+	border-radius: var(--radius-lg);
+	box-shadow: var(--shadow-sm);
+	text-align: center;
+}
+
+@media (min-width: 735px) {
+	.header-overflow-menu {
+		display: contents !important;
+	}
+}
+
+@media (max-width: 734px) {
+	#top-buttons {
+		width: 100%;
+		flex-wrap: nowrap;
+		gap: var(--spacing-2);
+	}
+
+	#top-buttons > button,
+	#top-buttons > select {
+		flex: 1 1 auto;
+		min-width: 0;
+	}
+
+	#top-buttons > #examples {
+		flex: 0 0 132px;
+		width: 132px;
+		min-width: 132px;
+	}
+
+	.header-overflow-dropdown {
+		display: inline-block;
+		position: relative;
+		flex: 0 0 auto;
+	}
+
+	.header-overflow-button {
+		display: inline-flex !important;
+		width: 40px;
+		border: 1px solid var(--border-component);
+		background: var(--surface-color);
+		color: var(--text-color);
+	}
+
+	.header-overflow-menu {
+		display: none;
+		bottom: auto;
+		top: calc(100% + var(--spacing-2));
+		width: min(260px, calc(100vw - var(--spacing-4)));
+		min-width: 230px;
+		max-width: calc(100vw - var(--spacing-4));
+		margin-bottom: 0;
+		padding: var(--spacing-2);
+		white-space: normal;
+	}
+
+	.header-overflow-menu > #options-wrapper,
+	.header-overflow-menu > select,
+	.header-overflow-menu > button {
+		display: block;
+		width: 100%;
+		box-sizing: border-box;
+		margin: 0;
+	}
+
+	.header-overflow-menu > *,
+	.header-overflow-menu #preview-mode {
+		min-width: 0;
+		max-width: 100%;
+	}
+
+	.header-overflow-menu > #options-wrapper,
+	.header-overflow-menu > select {
+		margin-bottom: var(--spacing-2);
+	}
+
+	.header-overflow-menu #toggle-further-options,
+	.header-overflow-menu #wizard-mode-toggle {
+		justify-content: flex-start;
+	}
+
+	.header-overflow-menu #toggle-further-options,
+	.header-overflow-menu #preview-mode,
+	.header-overflow-menu #wizard-mode-toggle {
+		width: 100%;
+	}
+
+	.desktop-instructions {
+		display: none;
+	}
+
+	.mobile-instructions {
+		display: inline;
+	}
 }
 
 #code-editor-container {

--- a/src/styles/_editor.css
+++ b/src/styles/_editor.css
@@ -142,6 +142,53 @@ button.code-editor {
 		padding: var(--spacing-2);
 	}
 
+	#code-editor[open] {
+		display: flex;
+		flex-direction: column;
+		position: fixed;
+		inset: 0;
+		width: 100vw;
+		height: 100vh;
+		height: 100dvh;
+		max-width: none;
+		max-height: none;
+		margin: 0;
+		padding: var(--spacing-4);
+		box-sizing: border-box;
+		border-radius: 0;
+	}
+
+	#code-editor p {
+		flex: 0 0 auto;
+		margin: 0 0 var(--spacing-4);
+		font-size: var(--font-size-base);
+		line-height: var(--line-height-normal);
+	}
+
+	#code-editor-container {
+		flex: 1 1 auto;
+		width: 100%;
+		height: auto;
+		min-height: 0;
+		box-sizing: border-box;
+	}
+
+	#code-editor-status {
+		flex: 0 0 auto;
+		width: 100%;
+		box-sizing: border-box;
+	}
+
+	#code-editor > br {
+		display: none;
+	}
+
+	#code-editor > button {
+		flex: 0 0 auto;
+		align-self: flex-start;
+		margin-top: var(--spacing-4);
+	}
+
 	header {
 		margin-bottom: var(--spacing-4);
 	}
@@ -234,21 +281,90 @@ button.code-editor {
 		border: 1px solid var(--border-color);
 	}
 
+	#blueprint-steps div.header {
+		flex-wrap: wrap;
+		justify-content: flex-start;
+		align-items: flex-start;
+		gap: var(--spacing-2) var(--spacing-3);
+	}
+
+	#blueprint-steps div.header .remove {
+		margin-left: auto;
+	}
+
+	#blueprint-steps .step.mine button.save-step {
+		display: none;
+	}
+
+	#blueprint-steps table.vars,
+	#blueprint-steps table.vars tbody,
+	#blueprint-steps table.vars tr,
+	#blueprint-steps table.vars td {
+		display: block;
+		width: 100%;
+		box-sizing: border-box;
+	}
+
+	#blueprint-steps table.vars tr td.label {
+		max-width: none;
+		padding: var(--spacing-3) 0 var(--spacing-1);
+		white-space: normal;
+	}
+
+	#blueprint-steps table.vars tr td.field {
+		padding: 0 0 var(--spacing-3);
+	}
+
+	#blueprint-steps td.field > textarea,
+	#blueprint-steps td.field > input[type="text"],
+	#blueprint-steps td.field > select {
+		width: 100%;
+		max-width: none;
+	}
+
+	#blueprint-steps button.code-editor {
+		display: inline-flex;
+		width: 100%;
+		margin: var(--spacing-2) 0 0;
+		box-sizing: border-box;
+	}
+
+	#blueprint-steps .examples ul {
+		overflow-x: visible;
+		padding-bottom: var(--spacing-1);
+	}
+
+	#blueprint-steps .examples ul li {
+		white-space: normal;
+		overflow-wrap: anywhere;
+	}
+
+	#blueprint-steps .examples.for-textarea ul li {
+		display: block;
+		max-width: 100%;
+		margin: var(--spacing-2) 0 0;
+		white-space: pre-wrap;
+		overflow-wrap: anywhere;
+	}
+
 	#mobile-show-steps {
 		width: 100%;
 		margin-top: var(--spacing-2);
-		padding: var(--spacing-4);
-		background: var(--primary-500);
-		color: white;
-		border: 1px solid var(--primary-500);
+		padding: var(--spacing-3) var(--spacing-4);
+		background: light-dark(var(--primary-50), var(--primary-950));
+		color: light-dark(var(--primary-700), var(--primary-200));
+		border: 1px solid light-dark(var(--primary-200), var(--primary-700));
+		font-size: var(--font-size-sm);
 		font-weight: var(--font-weight-semibold);
-		box-shadow: var(--shadow-md);
+		line-height: var(--line-height-tight);
+		box-shadow: var(--shadow-sm);
 		border-radius: var(--radius-lg);
 	}
 
 	#mobile-show-steps:hover {
-		background: var(--primary-600);
-		border-color: var(--primary-600);
+		background: light-dark(var(--primary-100), var(--primary-900));
+		border-color: light-dark(var(--primary-300), var(--primary-600));
+		box-shadow: var(--shadow-md);
 	}
 
 	#draghint {
@@ -298,6 +414,44 @@ button.code-editor {
 	#blueprint-compiled-holder > div {
 		margin-bottom: var(--spacing-2);
 		font-size: var(--font-size-base);
+	}
+
+	#blueprint-compiled-header {
+		margin-bottom: var(--spacing-2);
+	}
+
+	#toggle-compiled-panel.mobile-only {
+		display: inline-flex !important;
+		padding: var(--spacing-2) var(--spacing-3);
+		font-size: var(--font-size-sm);
+	}
+
+	#blueprint-compiled-holder.mobile-collapsed #blueprint-compiled-header {
+		margin-bottom: 0;
+	}
+
+	#blueprint-compiled-holder.mobile-collapsed #history-button {
+		display: none;
+	}
+
+	#blueprint-compiled-holder.mobile-collapsed #blueprint-collapsed-stats {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		margin: var(--spacing-2) 0;
+		padding: var(--spacing-4);
+		background: var(--surface-color);
+		border: 1px dashed var(--border-color);
+		border-radius: var(--radius-lg);
+		color: var(--text-muted);
+		font-size: var(--font-size-sm);
+		font-weight: var(--font-weight-semibold);
+	}
+
+	#blueprint-compiled-holder.mobile-collapsed #blueprint-compiled-wrapper,
+	#blueprint-compiled-holder.mobile-collapsed #blueprint-version-selector,
+	#blueprint-compiled-holder.mobile-collapsed #blueprint-size-warning {
+		display: none !important;
 	}
 
 	#blueprint-version-selector {

--- a/src/styles/_history.css
+++ b/src/styles/_history.css
@@ -305,6 +305,58 @@
 	}
 }
 
+.history-detail-header h3 {
+	margin: 0 0 var(--spacing-1);
+	font-size: var(--font-size-xl);
+}
+
+.history-detail-description,
+.history-detail-date {
+	color: var(--text-muted);
+	line-height: var(--line-height-normal);
+}
+
+.history-detail-section {
+	margin-top: var(--spacing-4);
+}
+
+.history-detail-section h4 {
+	margin: 0 0 var(--spacing-3);
+	font-size: var(--font-size-base);
+}
+
+.personal-step-vars-list {
+	display: flex;
+	flex-direction: column;
+	gap: var(--spacing-3);
+	margin: 0;
+	padding: 0;
+	list-style: none;
+}
+
+.personal-step-vars-list li {
+	display: grid;
+	grid-template-columns: minmax(100px, 160px) 1fr;
+	gap: var(--spacing-3);
+	align-items: start;
+}
+
+.personal-step-vars-list strong {
+	font-family: var(--font-mono);
+	font-size: var(--font-size-sm);
+}
+
+.personal-step-vars-list code {
+	display: block;
+	padding: var(--spacing-2);
+	background: light-dark(var(--gray-100), var(--gray-800));
+	border: 1px solid var(--border-color);
+	border-radius: var(--radius-md);
+	white-space: pre-wrap;
+	overflow-wrap: anywhere;
+	font-size: var(--font-size-sm);
+}
+
 #history-detail-column {
 	display: flex;
 	flex-direction: column;
@@ -748,11 +800,16 @@
 		flex-wrap: wrap;
 	}
 
-	#history-actions button {
-		flex: 1 1 calc(50% - var(--spacing-1));
-	}
+		#history-actions button {
+			flex: 1 1 calc(50% - var(--spacing-1));
+		}
 
-	#history-mobile-back-btn {
+		.personal-step-vars-list li {
+			grid-template-columns: 1fr;
+			gap: var(--spacing-1);
+		}
+
+		#history-mobile-back-btn {
 		display: block !important;
 		width: 100%;
 		padding: var(--spacing-3) var(--spacing-4);

--- a/src/styles/_layout.css
+++ b/src/styles/_layout.css
@@ -89,22 +89,26 @@ body.split-view-right {
 		}
 	}
 
-	& #mobile-show-steps {
-		display: block;
-		width: 100%;
-		padding: var(--spacing-4);
-		background: var(--primary-500);
-		color: white;
-		border: 1px solid var(--primary-500);
-		font-weight: var(--font-weight-semibold);
-		box-shadow: var(--shadow-md);
-		border-radius: var(--radius-lg);
-		cursor: pointer;
+		& #mobile-show-steps {
+			display: block;
+			width: 100%;
+			padding: var(--spacing-3) var(--spacing-4);
+			background: light-dark(var(--primary-50), var(--primary-950));
+			color: light-dark(var(--primary-700), var(--primary-200));
+			border: 1px solid light-dark(var(--primary-200), var(--primary-700));
+			font-size: var(--font-size-sm);
+			font-weight: var(--font-weight-semibold);
+			line-height: var(--line-height-tight);
+			box-shadow: var(--shadow-sm);
+			border-radius: var(--radius-lg);
+			cursor: pointer;
 
-		&:hover {
-			background: var(--primary-600);
+			&:hover {
+				background: light-dark(var(--primary-100), var(--primary-900));
+				border-color: light-dark(var(--primary-300), var(--primary-600));
+				box-shadow: var(--shadow-md);
+			}
 		}
-	}
 
 	& #blueprint-compiled-holder {
 		width: 100%;

--- a/src/styles/_steps.css
+++ b/src/styles/_steps.css
@@ -216,7 +216,7 @@
 				}
 
 				&::after {
-					content: "\u22EE";
+					content: "⋮";
 					display: block;
 				}
 			}
@@ -233,7 +233,7 @@
 					right: var(--spacing-2);
 
 					&::after {
-						content: "\u22EE";
+						content: "⋮";
 					}
 				}
 
@@ -348,7 +348,7 @@
 		}
 
 		& a.view-source,
-		& button.save-step {
+		&.show-save-step button.save-step {
 			display: block;
 		}
 
@@ -379,9 +379,11 @@ div.header {
 
 	& span.stepname {
 		flex-grow: 1;
+		min-width: 0;
 		font-family: var(--font-mono);
 		font-size: var(--font-size-sm);
 		font-weight: var(--font-weight-medium);
+		overflow-wrap: anywhere;
 	}
 
 	& button,
@@ -594,8 +596,7 @@ select {
 }
 
 #blueprint-version-selector {
-	margin-top: var(--spacing-4);
-	margin-bottom: var(--spacing-4);
+	display: none;
 }
 
 .blueprint-warning {


### PR DESCRIPTION
## Summary
- Clean up the mobile header with an overflow menu for secondary controls
- Collapse the blueprint editor on mobile while keeping launch actions visible
- Improve mobile step cards, code editor, My Blueprints detail pane, and custom step details

## Testing
- npx tsc --noEmit
- npm run build:ui