### PR TITLE
Rewrite GitHub blueprint URLs to raw URLs

### DIFF
--- a/src/frontend/query-params.test.ts
+++ b/src/frontend/query-params.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { getBlueprintUrlParam, rewriteGitHubUrlToRaw } from './query-params';
+
+describe( 'query params', () => {
+	afterEach( () => {
+		window.history.pushState( {}, '', '/' );
+	} );
+
+	describe( 'rewriteGitHubUrlToRaw', () => {
+		it( 'rewrites GitHub blob file URLs to raw GitHub URLs', () => {
+			expect(
+				rewriteGitHubUrlToRaw( 'https://github.com/example/repo/blob/main/blueprint.json' )
+			).toBe( 'https://raw.githubusercontent.com/example/repo/main/blueprint.json' );
+		} );
+
+		it( 'rewrites nested GitHub blob file URLs and preserves query params', () => {
+			expect(
+				rewriteGitHubUrlToRaw( 'https://github.com/example/repo/blob/trunk/path/to/blueprint.json?raw=1' )
+			).toBe( 'https://raw.githubusercontent.com/example/repo/trunk/path/to/blueprint.json?raw=1' );
+		} );
+
+		it( 'rewrites GitHub raw file URLs to raw.githubusercontent.com URLs', () => {
+			expect(
+				rewriteGitHubUrlToRaw( 'https://github.com/example/repo/raw/main/blueprint.json' )
+			).toBe( 'https://raw.githubusercontent.com/example/repo/main/blueprint.json' );
+		} );
+
+		it( 'leaves non-GitHub URLs unchanged', () => {
+			const url = 'https://example.com/blueprint.json';
+			expect( rewriteGitHubUrlToRaw( url ) ).toBe( url );
+		} );
+
+		it( 'leaves data URLs unchanged', () => {
+			const url = 'data:application/json;base64,eyJzdGVwcyI6W119';
+			expect( rewriteGitHubUrlToRaw( url ) ).toBe( url );
+		} );
+	} );
+
+	describe( 'getBlueprintUrlParam', () => {
+		it( 'returns a rewritten GitHub blueprint-url parameter', () => {
+			const githubUrl = 'https://github.com/example/repo/blob/main/blueprint.json';
+			window.history.pushState( {}, '', `/?blueprint-url=${encodeURIComponent( githubUrl )}` );
+
+			expect( getBlueprintUrlParam() ).toBe(
+				'https://raw.githubusercontent.com/example/repo/main/blueprint.json'
+			);
+		} );
+	} );
+} );

--- a/src/frontend/query-params.ts
+++ b/src/frontend/query-params.ts
@@ -19,7 +19,40 @@ export interface BlueprintQueryParams {
  */
 export function getBlueprintUrlParam(): string | null {
 	const urlParams = new URLSearchParams(window.location.search);
-	return urlParams.get('blueprint-url');
+	const blueprintUrl = urlParams.get('blueprint-url');
+	return blueprintUrl ? rewriteGitHubUrlToRaw( blueprintUrl ) : null;
+}
+
+/**
+ * Rewrite GitHub file URLs to raw.githubusercontent.com URLs so they can be fetched directly.
+ */
+export function rewriteGitHubUrlToRaw( url: string ): string {
+	let parsedUrl: URL;
+	try {
+		parsedUrl = new URL( url );
+	} catch ( e ) {
+		return url;
+	}
+
+	if ( parsedUrl.protocol !== 'https:' && parsedUrl.protocol !== 'http:' ) {
+		return url;
+	}
+
+	if ( parsedUrl.hostname !== 'github.com' && parsedUrl.hostname !== 'www.github.com' ) {
+		return url;
+	}
+
+	const pathParts = parsedUrl.pathname.split( '/' ).filter( Boolean );
+	const [ owner, repo, fileUrlType, ref, ...filePath ] = pathParts;
+	if ( !owner || !repo || !ref || filePath.length === 0 ) {
+		return url;
+	}
+
+	if ( fileUrlType !== 'blob' && fileUrlType !== 'raw' ) {
+		return url;
+	}
+
+	return `https://raw.githubusercontent.com/${owner}/${repo}/${ref}/${filePath.join( '/' )}${parsedUrl.search}`;
 }
 
 /**


### PR DESCRIPTION
## Summary
- rewrite GitHub blob/raw blueprint-url values to raw.githubusercontent.com before fetch
- preserve non-GitHub and data URLs unchanged
- add query-param coverage for the rewrite behavior

## Tests
- npx vitest run src/frontend/query-params.test.ts
- npx tsc --noEmit