### PR TITLE
Add theme review environment example

### DIFF
--- a/bin/generate-schema.js
+++ b/bin/generate-schema.js
@@ -106,6 +106,13 @@ function generateSchema() {
                 },
                 additionalProperties: false
             },
+            extraLibraries: {
+                type: 'array',
+                items: {
+                    type: 'string',
+                    enum: ['wp-cli']
+                }
+            },
             steps: {
                 type: 'array',
                 items: { oneOf: stepRefs }

--- a/docs/steps-reference.md
+++ b/docs/steps-reference.md
@@ -487,6 +487,7 @@ This document provides detailed information about all available steps, including
 |----------|------|----------|-------------|
 | `wpDebug` | boolean | ❌ No | Enable WordPress debug mode |
 | `wpDebugDisplay` | boolean | ❌ No | Display errors in HTML output. Only applies when the above is enabled. |
+| `wpDebugLog` | boolean | ❌ No | Write debug messages and PHP errors to wp-content/debug.log. Only applies when debug mode is enabled. |
 | `scriptDebug` | boolean | ❌ No | Use non-minified JavaScript and CSS files. |
 | `queryMonitor` | boolean | ❌ No | Install Query Monitor plugin. |
 
@@ -499,6 +500,7 @@ This document provides detailed information about all available steps, including
           "vars": {
                 "wpDebug": false,
                 "wpDebugDisplay": false,
+                "wpDebugLog": false,
                 "scriptDebug": false,
                 "queryMonitor": false
           }

--- a/docs/steps/debug.md
+++ b/docs/steps/debug.md
@@ -17,6 +17,7 @@ Configure WordPress debug settings and optionally install Query Monitor plugin.
 |----------|------|----------|-------------|
 | `wpDebug` | boolean | ❌ No | Enable WordPress debug mode |
 | `wpDebugDisplay` | boolean | ❌ No | Display errors in HTML output. Only applies when the above is enabled. |
+| `wpDebugLog` | boolean | ❌ No | Write debug messages and PHP errors to wp-content/debug.log. Only applies when debug mode is enabled. |
 | `scriptDebug` | boolean | ❌ No | Use non-minified JavaScript and CSS files. |
 | `queryMonitor` | boolean | ❌ No | Install Query Monitor plugin. |
 
@@ -76,6 +77,7 @@ const blueprint = {
           "vars": {
                 "wpDebug": false,
                 "wpDebugDisplay": false,
+                "wpDebugLog": false,
                 "scriptDebug": false,
                 "queryMonitor": false
           }

--- a/src/examples/theme-review-environment.json
+++ b/src/examples/theme-review-environment.json
@@ -1,0 +1,58 @@
+{
+	"$schema": "../../step-library-schema.json",
+	"meta": {
+		"title": "Theme Review Environment"
+	},
+	"extraLibraries": [
+		"wp-cli"
+	],
+	"steps": [
+		{
+			"step": "installTheme",
+			"vars": {
+				"url": ""
+			}
+		},
+		{
+			"step": "setSiteOption",
+			"vars": {
+				"name": "blogname",
+				"value": "Theme Review Environment"
+			}
+		},
+		{
+			"step": "debug",
+			"vars": {
+				"wpDebug": true,
+				"wpDebugDisplay": false,
+				"wpDebugLog": true,
+				"queryMonitor": true
+			}
+		},
+		{
+			"step": "installPlugin",
+			"vars": {
+				"url": "theme-check"
+			}
+		},
+		{
+			"step": "installPlugin",
+			"vars": {
+				"url": "log-deprecated-notices"
+			}
+		},
+		{
+			"step": "importWxr",
+			"vars": {
+				"url": "https://raw.githubusercontent.com/WordPress/theme-test-data/master/themeunittestdata.wordpress.xml"
+			}
+		},
+		{
+			"step": "login",
+			"vars": {
+				"username": "admin",
+				"password": "password"
+			}
+		}
+	]
+}

--- a/src/frontend/blueprint-compiler.ts
+++ b/src/frontend/blueprint-compiler.ts
@@ -22,6 +22,7 @@ export interface CompressedState {
 	wpVersion?: string;
 	phpVersion?: string;
 	blueprintVersion?: string;
+	extraLibraries?: string[];
 }
 
 /**
@@ -39,6 +40,7 @@ export function compressState(
 		wpVersion?: string;
 		phpVersion?: string;
 		blueprintVersion?: string;
+		extraLibraries?: string[];
 	}
 ): string {
 	const state: CompressedState = {
@@ -71,6 +73,9 @@ export function compressState(
 	}
 	if (options.blueprintVersion && options.blueprintVersion !== 'v1') {
 		state.blueprintVersion = options.blueprintVersion;
+	}
+	if (options.extraLibraries && options.extraLibraries.length > 0) {
+		state.extraLibraries = options.extraLibraries;
 	}
 
 	const json = JSON.stringify(state);

--- a/src/frontend/examples.ts
+++ b/src/frontend/examples.ts
@@ -9,13 +9,19 @@ export interface ExampleStep {
 	vars: Record<string, any>;
 }
 
-export type Examples = Record<string, ExampleStep[]>;
+export interface ExampleState {
+	steps: ExampleStep[];
+	extraLibraries?: string[];
+}
+
+export type Examples = Record<string, ExampleState>;
 
 interface ExampleModule {
 	meta: {
 		title: string;
 	};
 	steps: ExampleStep[];
+	extraLibraries?: string[];
 }
 
 const exampleModules = import.meta.glob<ExampleModule>( '/src/examples/*.json', { eager: true } );
@@ -25,6 +31,12 @@ export const examples: Examples = {};
 for ( const path in exampleModules ) {
 	const module = exampleModules[path];
 	if ( module.meta && module.meta.title ) {
-		examples[module.meta.title] = module.steps;
+		const exampleState: ExampleState = {
+			steps: module.steps
+		};
+		if ( module.extraLibraries ) {
+			exampleState.extraLibraries = module.extraLibraries;
+		}
+		examples[module.meta.title] = exampleState;
 	}
 }

--- a/src/frontend/main.ts
+++ b/src/frontend/main.ts
@@ -594,6 +594,10 @@ addEventListener('DOMContentLoaded', function () {
 			combinedExamples.title = titleEl.value;
 		}
 		const state: StepData[] = [];
+		const wpCliEl = document.getElementById( 'wp-cli' ) as HTMLInputElement | null;
+		if ( wpCliEl?.checked ) {
+			combinedExamples.extraLibraries = [ 'wp-cli' ];
+		}
 
 		blueprintSteps.querySelectorAll( '.step' ).forEach( function ( stepBlock ) {
 			updateVariableVisibility( stepBlock as HTMLElement );
@@ -777,7 +781,7 @@ addEventListener('DOMContentLoaded', function () {
 			return;
 		}
 		( document.getElementById( 'title' ) as HTMLInputElement ).value = this.value;
-		stateController.restoreState( { steps: examples[this.value] } );
+		stateController.restoreState( { extraLibraries: [], ...examples[this.value] } );
 		blueprintEventBus.emit( 'blueprint:updated' );
 	} );
 	stepLibraryController.clearFilter();

--- a/src/frontend/state-controller.test.ts
+++ b/src/frontend/state-controller.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { StateController, type StateControllerDependencies } from './state-controller';
 import { blueprintEventBus } from './blueprint-event-bus';
+import { uncompressState } from './blueprint-compiler';
 
 describe('StateController', () => {
 	let controller: StateController;
@@ -25,7 +26,8 @@ describe('StateController', () => {
 			playground: createInputElement('playground', 'text', 'playground.wordpress.net'),
 			mode: createSelectElement('mode', 'browser-full-screen'),
 			previewMode: createInputElement('preview-mode', 'text', ''),
-			excludeMeta: createCheckboxElement('exclude-meta', false)
+			excludeMeta: createCheckboxElement('exclude-meta', false),
+			wpCli: createCheckboxElement('wp-cli', false)
 		};
 
 		Object.values(mockElements).forEach(el => document.body.appendChild(el));
@@ -93,6 +95,14 @@ describe('StateController', () => {
 
 			const result = controller.compressStateFromDOM(steps);
 			expect(result).toBeTruthy();
+		});
+
+		it('should compress state with wp-cli extra library', () => {
+			(mockElements.wpCli as HTMLInputElement).checked = true;
+			const steps = [{ step: 'login' }];
+
+			const result = controller.compressStateFromDOM(steps);
+			expect(uncompressState(result).extraLibraries).toEqual(['wp-cli']);
 		});
 
 		it('should handle missing form elements gracefully', () => {
@@ -205,6 +215,27 @@ describe('StateController', () => {
 
 			controller.restoreState(state);
 			expect((mockElements.excludeMeta as HTMLInputElement).checked).toBe(true);
+		});
+
+		it('should restore wp-cli extra library', () => {
+			const state = {
+				steps: [],
+				extraLibraries: ['wp-cli']
+			};
+
+			controller.restoreState(state);
+			expect((mockElements.wpCli as HTMLInputElement).checked).toBe(true);
+		});
+
+		it('should clear wp-cli when extraLibraries is empty', () => {
+			(mockElements.wpCli as HTMLInputElement).checked = true;
+			const state = {
+				steps: [],
+				extraLibraries: []
+			};
+
+			controller.restoreState(state);
+			expect((mockElements.wpCli as HTMLInputElement).checked).toBe(false);
 		});
 
 		it('should not restore excludeMeta if undefined', () => {

--- a/src/frontend/state-controller.ts
+++ b/src/frontend/state-controller.ts
@@ -33,6 +33,8 @@ export class StateController {
 		const wpVersionEl = document.getElementById('wp-version') as HTMLSelectElement;
 		const phpVersionEl = document.getElementById('php-version') as HTMLSelectElement;
 		const blueprintVersionEl = document.querySelector('input[name="blueprint-version"]:checked') as HTMLInputElement;
+		const wpCliEl = document.getElementById('wp-cli') as HTMLInputElement;
+		const extraLibraries = wpCliEl?.checked ? ['wp-cli'] : undefined;
 
 		return compressState(steps, {
 			title: titleEl?.value || undefined,
@@ -43,7 +45,8 @@ export class StateController {
 			excludeMeta: excludeMetaEl?.checked || undefined,
 			wpVersion: wpVersionEl?.value || undefined,
 			phpVersion: phpVersionEl?.value || undefined,
-			blueprintVersion: blueprintVersionEl?.value || undefined
+			blueprintVersion: blueprintVersionEl?.value || undefined,
+			extraLibraries
 		});
 	}
 
@@ -74,6 +77,12 @@ export class StateController {
 		}
 		if (state.excludeMeta !== undefined) {
 			(document.getElementById('exclude-meta') as HTMLInputElement).checked = state.excludeMeta;
+		}
+		if (state.extraLibraries !== undefined) {
+			const wpCliEl = document.getElementById('wp-cli') as HTMLInputElement | null;
+			if (wpCliEl) {
+				wpCliEl.checked = Array.isArray(state.extraLibraries) && state.extraLibraries.includes('wp-cli');
+			}
 		}
 		if (state.wpVersion) {
 			(document.getElementById('wp-version') as HTMLSelectElement).value = state.wpVersion;

--- a/src/frontend/types.ts
+++ b/src/frontend/types.ts
@@ -45,6 +45,7 @@ export interface AppState {
 	mode?: string;
 	previewMode?: string;
 	excludeMeta?: boolean;
+	extraLibraries?: string[];
 }
 
 export interface WizardState {
@@ -88,6 +89,7 @@ export interface StepConfig {
 export interface CombinedExamples {
 	title?: string;
 	landingPage: string;
+	extraLibraries?: string[];
 	steps: any[];
 }
 

--- a/src/v1-compiler.ts
+++ b/src/v1-compiler.ts
@@ -187,7 +187,7 @@ class StepLibraryCompiler {
             // the step using our custom functions or pass it through as a builtin step.
             // Use discriminated union logic to determine step type
             if (step.step === 'installPlugin') {
-                if (step.vars?.url) {
+                if (step.vars && Object.prototype.hasOwnProperty.call(step.vars, 'url')) {
                     // Custom installPlugin step - transform it
                     customStepResult = this.executeCustomStep(step.step, step, inputData);
                 } else {
@@ -195,7 +195,7 @@ class StepLibraryCompiler {
                     customStepResult = { steps: [step as StepDefinition] };
                 }
             } else if (step.step === 'installTheme') {
-                if (step.vars?.url) {
+                if (step.vars && Object.prototype.hasOwnProperty.call(step.vars, 'url')) {
                     // Custom installTheme step - transform it
                     customStepResult = this.executeCustomStep(step.step, step, inputData);
                 } else {

--- a/step-library-schema.json
+++ b/step-library-schema.json
@@ -30,6 +30,15 @@
       },
       "additionalProperties": false
     },
+    "extraLibraries": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": [
+          "wp-cli"
+        ]
+      }
+    },
     "steps": {
       "type": "array",
       "items": {
@@ -882,6 +891,10 @@
             "wpDebugDisplay": {
               "type": "boolean",
               "description": "Display errors in HTML output. Only applies when the above is enabled."
+            },
+            "wpDebugLog": {
+              "type": "boolean",
+              "description": "Write debug messages and PHP errors to wp-content/debug.log. Only applies when debug mode is enabled."
             },
             "scriptDebug": {
               "type": "boolean",

--- a/steps/debug.spec.ts
+++ b/steps/debug.spec.ts
@@ -53,6 +53,20 @@ describe( 'debug', () => {
 			expect( configStep?.consts.WP_DEBUG_DISPLAY ).toBe( false );
 		} );
 
+		it( 'should not set WP_DEBUG_LOG by default', () => {
+			const result = debug( { step: 'debug' }, createMockContext() ).toV1();
+
+			const configStep = result.steps?.find( r => r.step === 'defineWpConfigConsts' );
+			expect( configStep?.consts.WP_DEBUG_LOG ).toBeUndefined();
+		} );
+
+		it( 'should set WP_DEBUG_LOG when enabled', () => {
+			const result = debug( { step: 'debug', vars: { wpDebugLog: true } }, createMockContext() ).toV1();
+
+			const configStep = result.steps?.find( r => r.step === 'defineWpConfigConsts' );
+			expect( configStep?.consts.WP_DEBUG_LOG ).toBe( true );
+		} );
+
 		it( 'should set SCRIPT_DEBUG when enabled', () => {
 			const result = debug( { step: 'debug', vars: { scriptDebug: true } }, createMockContext() ).toV1();
 
@@ -97,12 +111,14 @@ describe( 'debug', () => {
 				step: 'debug', vars: {
 				wpDebug: true,
 				wpDebugDisplay: false,
+				wpDebugLog: true,
 				scriptDebug: true
 			} }, createMockContext() ).toV1();
 
 			const configStep = result.steps?.find( r => r.step === 'defineWpConfigConsts' );
 			expect( configStep?.consts.WP_DEBUG ).toBe( true );
 			expect( configStep?.consts.WP_DEBUG_DISPLAY ).toBe( false );
+			expect( configStep?.consts.WP_DEBUG_LOG ).toBe( true );
 			expect( configStep?.consts.SCRIPT_DEBUG ).toBe( true );
 
 			const installStep = result.steps?.find( r => r.step === 'installPlugin' );

--- a/steps/debug.ts
+++ b/steps/debug.ts
@@ -8,6 +8,7 @@ export const debug: StepFunction<DebugStep> = ( step: DebugStep, context?: Compi
 		toV1() {
 			const wpDebug = step.vars?.wpDebug !== false;
 			const wpDebugDisplay = step.vars?.wpDebugDisplay !== false;
+			const wpDebugLog = step.vars?.wpDebugLog === true;
 			const scriptDebug = step.vars?.scriptDebug === true;
 			const queryMonitor = step.vars?.queryMonitor !== false;
 
@@ -19,6 +20,9 @@ export const debug: StepFunction<DebugStep> = ( step: DebugStep, context?: Compi
 
 			if ( wpDebug ) {
 				consts.WP_DEBUG_DISPLAY = wpDebugDisplay;
+				if ( wpDebugLog ) {
+					consts.WP_DEBUG_LOG = true;
+				}
 			}
 
 			if ( scriptDebug ) {
@@ -58,6 +62,13 @@ debug.vars = [
 	{
 		name: "wpDebugDisplay",
 		description: "Display errors in HTML output. Only applies when the above is enabled.",
+		type: "boolean",
+		required: false,
+		show: (step: DebugStep) => step.vars?.wpDebug !== false
+	},
+	{
+		name: "wpDebugLog",
+		description: "Write debug messages and PHP errors to wp-content/debug.log. Only applies when debug mode is enabled.",
 		type: "boolean",
 		required: false,
 		show: (step: DebugStep) => step.vars?.wpDebug !== false

--- a/steps/installPlugin.spec.ts
+++ b/steps/installPlugin.spec.ts
@@ -18,6 +18,17 @@ function createMockContext(): CompilationContext & { queryParams: Record<string,
 }
 
 describe('installPlugin', () => {
+    it('should return no V1 steps for empty url', () => {
+        const step: InstallPluginStep = {
+            step: 'installPlugin', vars: {
+            url: ''
+        } };
+
+        const result = installPlugin(step).toV1();
+
+        expect(result.steps).toEqual([]);
+    });
+
     it('should install plugin from WordPress.org slug', () => {
         const step: InstallPluginStep = {
             step: 'installPlugin', vars: {
@@ -397,7 +408,7 @@ describe('installPlugin', () => {
         expect(typeof prsVar.show).toBe('function');
     });
 
-    it('should handle empty or malformed URLs gracefully', () => {
+    it('should return empty steps for empty URL', () => {
         const step: InstallPluginStep = {
             step: 'installPlugin', vars: {
             url: ''
@@ -406,7 +417,6 @@ describe('installPlugin', () => {
         const result = installPlugin(step).toV1();
 
         expect(Array.isArray(result.steps)).toBe(true);
-        expect(result.steps).toHaveLength(1);
-        expect(result.steps[0].step).toBe('installPlugin');
+        expect(result.steps).toHaveLength(0);
     });
 });

--- a/steps/installPlugin.ts
+++ b/steps/installPlugin.ts
@@ -21,6 +21,13 @@ export const installPlugin: StepFunction<InstallPluginStep> = ( step: InstallPlu
 		plugin = slugTest.groups!.slug;
 	}
 
+	if ( !plugin ) {
+		return {
+			toV1() { return { steps: [] }; },
+			toV2() { return { version: 2 }; }
+		};
+	}
+
 	// WordPress.org plugins and direct URLs
 	return {
 		toV1() {

--- a/steps/installTheme.spec.ts
+++ b/steps/installTheme.spec.ts
@@ -18,6 +18,17 @@ function createMockContext(): CompilationContext & { queryParams: Record<string,
 }
 
 describe('installTheme', () => {
+    it('should return no V1 steps for empty url', () => {
+        const step: InstallThemeStep = {
+            step: 'installTheme', vars: {
+            url: ''
+        } };
+
+        const result = installTheme(step).toV1();
+
+        expect(result.steps).toEqual([]);
+    });
+
     it('should install theme from WordPress.org slug', () => {
         const step: InstallThemeStep = {
             step: 'installTheme', vars: {

--- a/steps/types.ts
+++ b/steps/types.ts
@@ -597,6 +597,7 @@ export interface DebugStep extends BlueprintStep {
 	vars?: {
 		wpDebug?: boolean;
 		wpDebugDisplay?: boolean;
+		wpDebugLog?: boolean;
 		scriptDebug?: boolean;
 		queryMonitor?: boolean;
 	};
@@ -630,4 +631,3 @@ export interface SiteHealthImportStep extends BlueprintStep {
 		installLatest?: boolean;
 	};
 }
-

--- a/test/library.test.js
+++ b/test/library.test.js
@@ -92,6 +92,28 @@ describe('PlaygroundStepLibrary', () => {
       expect(compiled.steps.length).toBeGreaterThanOrEqual(2);
     });
 
+    it('should treat empty installTheme and installPlugin URLs as no-op custom steps', () => {
+      const blueprint = {
+        steps: [
+          {
+            step: 'installTheme',
+            vars: {
+              url: ''
+            }
+          },
+          {
+            step: 'installPlugin',
+            vars: {
+              url: ''
+            }
+          }
+        ]
+      };
+
+      const compiled = compiler.compile(blueprint);
+      expect(compiled.steps).toBeUndefined();
+    });
+
     it('should handle JSON string input', () => {
       const blueprint = {
         steps: [


### PR DESCRIPTION

<img width="2916" height="1918" alt="Screenshot 2026-05-08 at 17 22 32" src="https://github.com/user-attachments/assets/c029890c-ed54-464d-aa31-74f2d9962481" />


## Summary
- add a Theme Review Environment example built from existing steps
- support example-level extraLibraries so loading the example ticks the WP-CLI preload checkbox
- add WP_DEBUG_LOG support to the debug step and make empty installTheme/installPlugin wrapper URLs compile as no-ops

## Testing
- npm test
- npm run build:ui