### PR TITLE
Add example preload links

### DIFF
--- a/bin/generate-docs.js
+++ b/bin/generate-docs.js
@@ -52,7 +52,8 @@ class StepDocumentationGenerator {
         const docs = {
             readme: this.generateMainReadme(),
             stepsList: this.generateStepsList(),
-            individualDocs: this.generateIndividualStepDocs()
+            individualDocs: this.generateIndividualStepDocs(),
+            examples: this.generateExamplesDoc()
         };
 
         // Ensure docs directories exist
@@ -64,6 +65,9 @@ class StepDocumentationGenerator {
 
         // Write steps list
         this.writeFileIfChanged('docs/steps-reference.md', docs.stepsList);
+
+        // Write examples documentation
+        this.writeFileIfChanged('docs/examples.md', docs.examples);
 
         // Write individual step docs
         Object.entries(docs.individualDocs).forEach(([stepName, content]) => {
@@ -187,6 +191,7 @@ ${customSteps.map(([name, info]) =>
 
 - [← Back to Main Documentation](../README.md)
 - [Complete Steps Reference](../steps-reference.md) - All steps in one page
+- [Examples](../examples.md) - Preloadable example blueprints
 - [Built-in Step Usage](../builtin-step-usage.md) - See which steps compile to each built-in step
 `;
     }
@@ -256,6 +261,7 @@ Many steps can reference and use other steps. For example:
 
 - [Complete Steps Reference](steps-reference.md) - Detailed list with all parameters
 - [Individual Step Documentation](steps/) - Comprehensive docs for each step
+- [Examples](examples.md) - Preloadable example blueprints
 - [Built-in Step Usage](builtin-step-usage.md) - See which steps compile to each built-in step
 
 ## 🛠️ Contributing
@@ -267,6 +273,59 @@ See our [Contributing Guide](../CONTRIBUTING.md) for details on:
 - Testing your changes
 - Submitting pull requests
 `;
+    }
+
+    /**
+     * Read example blueprints from src/examples.
+     */
+    getExamples() {
+        const examplesDir = path.join(process.cwd(), 'src/examples');
+
+        if (!fs.existsSync(examplesDir)) {
+            return [];
+        }
+
+        return fs.readdirSync(examplesDir)
+            .filter(filename => filename.endsWith('.json'))
+            .map(filename => {
+                const filepath = path.join(examplesDir, filename);
+                const example = JSON.parse(fs.readFileSync(filepath, 'utf8'));
+                const slug = filename.replace(/\.json$/, '');
+                return {
+                    slug,
+                    title: example.meta?.title || slug,
+                    steps: Array.isArray(example.steps) ? example.steps : [],
+                    extraLibraries: Array.isArray(example.extraLibraries) ? example.extraLibraries : []
+                };
+            })
+            .sort((a, b) => a.title.localeCompare(b.title));
+    }
+
+    /**
+     * Generate examples documentation.
+     */
+    generateExamplesDoc() {
+        const examples = this.getExamples();
+        const uiUrl = 'https://akirk.github.io/playground-step-library/';
+
+        let content = `# Examples
+
+These links preload the example blueprints in the Step Library Web UI.
+
+| Example | Preload Link | Steps | Extra Libraries |
+|---------|--------------|-------|-----------------|
+`;
+
+        examples.forEach(example => {
+            const preloadUrl = `${uiUrl}?example=${encodeURIComponent(example.slug)}`;
+            const preloadLabel = `?example=${example.slug}`;
+            const steps = example.steps.map(step => `\`${step.step || 'unknown'}\``).join(', ') || 'None';
+            const extraLibraries = example.extraLibraries.map(library => `\`${library}\``).join(', ') || 'None';
+
+            content += `| ${example.title} | [\`${preloadLabel}\`](${preloadUrl}) | ${steps} | ${extraLibraries} |\n`;
+        });
+
+        return content;
     }
 
     /**

--- a/docs/README.md
+++ b/docs/README.md
@@ -122,6 +122,7 @@ Many steps can reference and use other steps. For example:
 
 - [Complete Steps Reference](steps-reference.md) - Detailed list with all parameters
 - [Individual Step Documentation](steps/) - Comprehensive docs for each step
+- [Examples](examples.md) - Preloadable example blueprints
 - [Built-in Step Usage](builtin-step-usage.md) - See which steps compile to each built-in step
 
 ## 🛠️ Contributing

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,0 +1,11 @@
+# Examples
+
+These links preload the example blueprints in the Step Library Web UI.
+
+| Example | Preload Link | Steps | Extra Libraries |
+|---------|--------------|-------|-----------------|
+| ActivityPub plugin preview | [`?example=activitypub-preview`](https://akirk.github.io/playground-step-library/?example=activitypub-preview) | `installPlugin`, `showAdminNotice`, `setSiteName`, `createUser`, `setLandingPage` | None |
+| Interactivity API Todo list MVC | [`?example=interactivity-api-todomvc`](https://akirk.github.io/playground-step-library/?example=interactivity-api-todomvc) | `addPage`, `installPlugin`, `login` | None |
+| Load Feeds into the Friends plugin | [`?example=friends-feeds`](https://akirk.github.io/playground-step-library/?example=friends-feeds) | `setLandingPage`, `installPlugin`, `importFriendFeeds` | None |
+| Show the available PHP extensions + PHPinfo | [`?example=php-extensions-phpinfo`](https://akirk.github.io/playground-step-library/?example=php-extensions-phpinfo) | `addFilter` | None |
+| Theme Review Environment | [`?example=theme-review-environment`](https://akirk.github.io/playground-step-library/?example=theme-review-environment) | `installTheme`, `setSiteOption`, `debug`, `installPlugin`, `installPlugin`, `importWxr`, `login` | `wp-cli` |

--- a/docs/steps/README.md
+++ b/docs/steps/README.md
@@ -92,4 +92,5 @@ Extended functionality beyond core WordPress Playground capabilities.
 
 - [← Back to Main Documentation](../README.md)
 - [Complete Steps Reference](../steps-reference.md) - All steps in one page
+- [Examples](../examples.md) - Preloadable example blueprints
 - [Built-in Step Usage](../builtin-step-usage.md) - See which steps compile to each built-in step

--- a/src/frontend/examples.test.ts
+++ b/src/frontend/examples.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { examples, examplesBySlug } from './examples';
+
+describe( 'examples', () => {
+	it( 'indexes examples by filename slug', () => {
+		const example = examplesBySlug['theme-review-environment'];
+
+		expect( example ).toBeDefined();
+		expect( example.title ).toBe( 'Theme Review Environment' );
+		expect( example.slug ).toBe( 'theme-review-environment' );
+		expect( example.extraLibraries ).toEqual( ['wp-cli'] );
+		expect( example.steps[0].step ).toBe( 'installTheme' );
+	} );
+
+	it( 'keeps the title index pointing to the same example state', () => {
+		expect( examples['Theme Review Environment'] ).toBe( examplesBySlug['theme-review-environment'] );
+	} );
+} );

--- a/src/frontend/examples.ts
+++ b/src/frontend/examples.ts
@@ -10,11 +10,14 @@ export interface ExampleStep {
 }
 
 export interface ExampleState {
+	title: string;
+	slug: string;
 	steps: ExampleStep[];
 	extraLibraries?: string[];
 }
 
 export type Examples = Record<string, ExampleState>;
+export type ExamplesBySlug = Record<string, ExampleState>;
 
 interface ExampleModule {
 	meta: {
@@ -27,16 +30,25 @@ interface ExampleModule {
 const exampleModules = import.meta.glob<ExampleModule>( '/src/examples/*.json', { eager: true } );
 
 export const examples: Examples = {};
+export const examplesBySlug: ExamplesBySlug = {};
+
+function getExampleSlug( path: string ): string {
+	return path.split( '/' ).pop()?.replace( /\.json$/, '' ) || path;
+}
 
 for ( const path in exampleModules ) {
 	const module = exampleModules[path];
 	if ( module.meta && module.meta.title ) {
+		const slug = getExampleSlug( path );
 		const exampleState: ExampleState = {
+			title: module.meta.title,
+			slug,
 			steps: module.steps
 		};
 		if ( module.extraLibraries ) {
 			exampleState.extraLibraries = module.extraLibraries;
 		}
 		examples[module.meta.title] = exampleState;
+		examplesBySlug[slug] = exampleState;
 	}
 }

--- a/src/frontend/main.ts
+++ b/src/frontend/main.ts
@@ -34,7 +34,7 @@ import { EventHandlersController, type EventHandlersControllerDependencies } fro
 import { AIInstructionsController, type AIInstructionsControllerDependencies } from './ai-instructions-controller';
 import { SaveDialogController } from './save-dialog-controller';
 import { processSteps } from './step-utils';
-import { examples } from './examples';
+import { examples, examplesBySlug, type ExampleState } from './examples';
 import { FileDropController, type FileDropControllerDependencies } from './file-drop-controller';
 
 declare global {
@@ -700,6 +700,26 @@ addEventListener('DOMContentLoaded', function () {
 		}
 	} )();
 
+	const examplesSelect = document.getElementById( 'examples' ) as HTMLSelectElement;
+	Object.keys( examples ).forEach( function ( example ) {
+		const option = document.createElement( 'option' );
+		option.value = example;
+		option.innerText = example;
+		examplesSelect.appendChild( option );
+	} );
+
+	function restoreExample( example: ExampleState ) {
+		examplesSelect.value = example.title;
+		stateController.restoreState( { extraLibraries: [], ...example } );
+		blueprintEventBus.emit( 'blueprint:updated' );
+	}
+
+	function removeExampleQueryParam() {
+		const newUrl = new URL( window.location.href );
+		newUrl.searchParams.delete( 'example' );
+		history.replaceState( null, '', newUrl.pathname + ( newUrl.search ? newUrl.search : '' ) + newUrl.hash );
+	}
+
 	const blueprintUrlParam = getBlueprintUrlParam();
 	if ( blueprintUrlParam ) {
 		// Fetch external blueprint from URL
@@ -748,41 +768,43 @@ addEventListener('DOMContentLoaded', function () {
 				blueprintEventBus.emit( 'blueprint:updated' );
 			} );
 	} else {
-	const queryParamBlueprint = parseQueryParamsForBlueprint();
-	if ( queryParamBlueprint ) {
-		if ( queryParamBlueprint.redir ) {
-			( document.getElementById( 'encoding-format' ) as HTMLSelectElement ).value = 'base64';
+		const exampleParam = new URLSearchParams( window.location.search ).get( 'example' );
+		const example = exampleParam ? examplesBySlug[exampleParam.trim().toLowerCase()] : null;
+		if ( example ) {
+			restoreExample( example );
+			removeExampleQueryParam();
+		} else {
+			if ( exampleParam ) {
+				toastService.showGlobal( `Example not found: ${exampleParam}`, { duration: 5000 } );
+			}
+			const queryParamBlueprint = parseQueryParamsForBlueprint();
+			if ( queryParamBlueprint ) {
+				if ( queryParamBlueprint.redir ) {
+					( document.getElementById( 'encoding-format' ) as HTMLSelectElement ).value = 'base64';
+				}
+				stateController.restoreState( { steps: queryParamBlueprint.steps } );
+				// Clear step[] and url[] parameters from URL to prevent conflicts with hash state
+				const newUrl = new URL( window.location.href );
+				newUrl.search = '';
+				history.replaceState( null, '', newUrl.pathname + newUrl.hash );
+				if ( queryParamBlueprint.redir && !( document.getElementById( 'preview-mode' ) as HTMLSelectElement ).value && !pageAccessedByReload ) {
+					stateController.autoredirect( queryParamBlueprint.redir );
+				}
+			} else if ( location.hash ) {
+				stateController.restoreState( blueprintCompiler.uncompressState( location.hash.replace( /^#+/, '' ) ) );
+				if ( !( document.getElementById( 'preview-mode' ) as HTMLSelectElement ).value && blueprintSteps.querySelectorAll( '.step' ).length && !pageAccessedByReload ) {
+					stateController.autoredirect();
+				}
+			} else {
+				blueprintEventBus.emit( 'blueprint:updated' );
+			}
 		}
-		stateController.restoreState( { steps: queryParamBlueprint.steps } );
-		// Clear step[] and url[] parameters from URL to prevent conflicts with hash state
-		const newUrl = new URL( window.location.href );
-		newUrl.search = '';
-		history.replaceState( null, '', newUrl.pathname + newUrl.hash );
-		if ( queryParamBlueprint.redir && !( document.getElementById( 'preview-mode' ) as HTMLSelectElement ).value && !pageAccessedByReload ) {
-			stateController.autoredirect( queryParamBlueprint.redir );
-		}
-	} else if ( location.hash ) {
-		stateController.restoreState( blueprintCompiler.uncompressState( location.hash.replace( /^#+/, '' ) ) );
-		if ( !( document.getElementById( 'preview-mode' ) as HTMLSelectElement ).value && blueprintSteps.querySelectorAll( '.step' ).length && !pageAccessedByReload ) {
-			stateController.autoredirect();
-		}
-	} else {
-		blueprintEventBus.emit( 'blueprint:updated' );
 	}
-	}
-	Object.keys( examples ).forEach( function ( example ) {
-		const option = document.createElement( 'option' );
-		option.value = example;
-		option.innerText = example;
-		document.getElementById( 'examples' )!.appendChild( option );
-	} );
-	document.getElementById( 'examples' )!.addEventListener( 'change', function ( this: HTMLSelectElement ) {
+	examplesSelect.addEventListener( 'change', function ( this: HTMLSelectElement ) {
 		if ( 'Examples' === this.value ) {
 			return;
 		}
-		( document.getElementById( 'title' ) as HTMLInputElement ).value = this.value;
-		stateController.restoreState( { extraLibraries: [], ...examples[this.value] } );
-		blueprintEventBus.emit( 'blueprint:updated' );
+		restoreExample( examples[this.value] );
 	} );
 	stepLibraryController.clearFilter();
 


### PR DESCRIPTION
## Summary
- Add ?example=<slug> support for loading examples by src/examples filename.
- Restore preloaded examples through the same path as the dropdown, including extraLibraries / WP-CLI.
- Generate https://github.com/akirk/playground-step-library/blob/preload-example-query-param/docs/examples.md with preload links for all examples.

## Testing
- npm run docs:generate
- npm test
- npm run build:lib
- npm run build:ui