### PR TITLE
Fix custom playground URL normalization

### DIFF
--- a/src/frontend/blueprint-compilation-controller.test.ts
+++ b/src/frontend/blueprint-compilation-controller.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { BlueprintCompilationController } from './blueprint-compilation-controller';
+import { isManualEditMode } from './app-state';
+
+describe('BlueprintCompilationController', () => {
+	let controller: BlueprintCompilationController;
+
+	beforeEach(() => {
+		document.body.textContent = '';
+		isManualEditMode.value = true;
+
+		const playground = document.createElement('input');
+		playground.id = 'playground';
+		playground.value = 'https://wordpress.com/setup/onboarding/playground';
+		document.body.appendChild(playground);
+
+		const playgroundLink = document.createElement('a');
+		playgroundLink.id = 'playground-link';
+		document.body.appendChild(playgroundLink);
+
+		const iframe = document.createElement('iframe');
+
+		controller = new BlueprintCompilationController({
+			getBlueprintValue: () => '{}',
+			setBlueprintValue: () => {},
+			blueprintUIDeps: {
+				playgroundIframe: iframe
+			}
+		});
+	});
+
+	afterEach(() => {
+		isManualEditMode.value = false;
+		document.body.textContent = '';
+	});
+
+	it('should not prefix https custom playground URLs again', () => {
+		controller.transformJson();
+
+		const playgroundLink = document.getElementById('playground-link') as HTMLAnchorElement;
+		expect(playgroundLink.href).toMatch(/^https:\/\/wordpress\.com\/setup\/onboarding\/playground\/#/);
+		expect(playgroundLink.href).not.toContain('https://https');
+	});
+});

--- a/src/frontend/blueprint-compilation-controller.ts
+++ b/src/frontend/blueprint-compilation-controller.ts
@@ -8,6 +8,7 @@ import { isManualEditMode, getBlueprint } from './app-state';
 import { encodeStringAsBase64 } from './utils';
 import { generateLabel } from './label-generator';
 import { updateBlueprintSizeWarning, handleSplitViewMode, type BlueprintUIDependencies } from './blueprint-ui';
+import { normalizeCustomPlaygroundUrl } from './custom-playgrounds';
 
 export interface BlueprintCompilationControllerDependencies {
 	getBlueprintValue: () => string;
@@ -204,7 +205,7 @@ export class BlueprintCompilationController {
 		const query = (queries.length ? '?' + queries.join('&') : '');
 		const playgroundEl = document.getElementById('playground') as HTMLInputElement;
 		const playground = playgroundEl ? playgroundEl.value : 'playground.wordpress.net';
-		const href = (playground.substr(0, 7) === 'http://' ? playground : 'https://' + playground) + '/' + query + hash;
+		const href = normalizeCustomPlaygroundUrl(playground) + '/' + query + hash;
 
 		const playgroundLinkEl = document.getElementById('playground-link') as HTMLAnchorElement;
 		if (playgroundLinkEl) {

--- a/src/frontend/custom-playgrounds.test.ts
+++ b/src/frontend/custom-playgrounds.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+	addCustomPlayground,
+	getCustomPlaygrounds,
+	normalizeCustomPlaygroundUrl
+} from './custom-playgrounds';
+
+describe('custom-playgrounds', () => {
+	beforeEach(() => {
+		localStorage.clear();
+	});
+
+	describe('normalizeCustomPlaygroundUrl', () => {
+		it('should preserve https URLs', () => {
+			expect(normalizeCustomPlaygroundUrl('https://wordpress.com/setup/onboarding/playground')).toBe(
+				'https://wordpress.com/setup/onboarding/playground'
+			);
+		});
+
+		it('should preserve http URLs', () => {
+			expect(normalizeCustomPlaygroundUrl('http://localhost:5400')).toBe('http://localhost:5400');
+		});
+
+		it('should add https to URLs without a protocol', () => {
+			expect(normalizeCustomPlaygroundUrl('wordpress.com/setup/onboarding/playground')).toBe(
+				'https://wordpress.com/setup/onboarding/playground'
+			);
+		});
+
+		it('should trim whitespace and trailing slashes', () => {
+			expect(normalizeCustomPlaygroundUrl(' https://wordpress.com/setup/onboarding/playground/ ')).toBe(
+				'https://wordpress.com/setup/onboarding/playground'
+			);
+		});
+	});
+
+	describe('addCustomPlayground', () => {
+		it('should store normalized playground URLs', () => {
+			addCustomPlayground('wordpress.com/setup/onboarding/playground/');
+
+			expect(getCustomPlaygrounds()).toEqual([
+				{
+					url: 'https://wordpress.com/setup/onboarding/playground',
+					name: 'https://wordpress.com/setup/onboarding/playground'
+				}
+			]);
+		});
+	});
+});

--- a/src/frontend/custom-playgrounds.ts
+++ b/src/frontend/custom-playgrounds.ts
@@ -3,11 +3,20 @@
  * Manage user-created custom playground URLs stored in localStorage
  */
 
+import { expandUrl } from './utils';
+
 const CUSTOM_PLAYGROUNDS_STORAGE_KEY = 'customPlaygrounds';
 
 export interface CustomPlayground {
 	url: string;
 	name: string;
+}
+
+/**
+ * Normalize a custom playground URL for storage and launch-link generation.
+ */
+export function normalizeCustomPlaygroundUrl(url: string): string {
+	return expandUrl(url.trim()).replace(/\/+$/, '');
 }
 
 /**
@@ -26,6 +35,7 @@ export function getCustomPlaygrounds(): CustomPlayground[] {
  * Add a custom playground to localStorage
  */
 export function addCustomPlayground(url: string, name?: string): void {
+	url = normalizeCustomPlaygroundUrl(url);
 	const playgrounds = getCustomPlaygrounds();
 	const displayName = name || url;
 


### PR DESCRIPTION
## Summary
- normalize custom playground base URLs before generating launch links
- preserve existing http/https schemes and avoid double-prefixing https URLs
- normalize custom playground URLs when saving them

## Testing
- npm test
- npm run build:ui