### PR TITLE
Fix redirect URL parsing for plugin slugs

### DIFF
--- a/src/frontend/query-params.test.ts
+++ b/src/frontend/query-params.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, afterEach } from 'vitest';
-import { getBlueprintUrlParam, rewriteGitHubUrlToRaw } from './query-params';
+import { getBlueprintUrlParam, parseQueryParamsForBlueprint, rewriteGitHubUrlToRaw } from './query-params';
 
 describe( 'query params', () => {
 	afterEach( () => {
@@ -44,6 +44,44 @@ describe( 'query params', () => {
 			expect( getBlueprintUrlParam() ).toBe(
 				'https://raw.githubusercontent.com/example/repo/main/blueprint.json'
 			);
+		} );
+	} );
+
+	describe( 'parseQueryParamsForBlueprint', () => {
+		it( 'preserves WordPress.org plugin slugs while expanding URL-like values', () => {
+			window.history.pushState(
+				{},
+				'',
+				'/?redir=1&step%5B0%5D=installPlugin&url%5B0%5D=advanced-custom-fields&step%5B1%5D=installPlugin&url%5B1%5D=github.com/akirk/family-wiki/tree/add-gedcom-import-export'
+			);
+
+			expect( parseQueryParamsForBlueprint() ).toEqual( {
+				steps: [
+					{
+						step: 'installPlugin',
+						vars: {
+							url: 'advanced-custom-fields'
+						}
+					},
+					{
+						step: 'installPlugin',
+						vars: {
+							url: 'https://github.com/akirk/family-wiki/tree/add-gedcom-import-export'
+						}
+					}
+				],
+				redir: 1
+			} );
+		} );
+
+		it( 'preserves short-form GitHub repository references', () => {
+			window.history.pushState(
+				{},
+				'',
+				'/?step%5B0%5D=installPlugin&url%5B0%5D=akirk/blueprint-recorder'
+			);
+
+			expect( parseQueryParamsForBlueprint()?.steps[0].vars.url ).toBe( 'akirk/blueprint-recorder' );
 		} );
 	} );
 } );

--- a/src/frontend/query-params.ts
+++ b/src/frontend/query-params.ts
@@ -56,6 +56,23 @@ export function rewriteGitHubUrlToRaw( url: string ): string {
 }
 
 /**
+ * Redirect URLs shorten URL-like values by removing the protocol. Add it back
+ * only for values that still look like a URL host, not for plugin/theme slugs.
+ */
+function expandUrlQueryValue( value: string ): string {
+	if ( value.match( /^https?:\/\// ) ) {
+		return value;
+	}
+
+	const firstPathSegment = value.split( '/' )[0];
+	if ( firstPathSegment.includes( '.' ) ) {
+		return expandUrl( value );
+	}
+
+	return value;
+}
+
+/**
  * Parse query parameters into blueprint configuration
  * Supports array-indexed parameters like step[0], step[1], url[0], url[1], etc.
  */
@@ -93,7 +110,7 @@ export function parseQueryParamsForBlueprint(): BlueprintQueryParams | null {
 				if (paramName !== 'step' && values[parseInt(index)] !== undefined) {
 					let value = values[parseInt(index)];
 					if (paramName === 'url' || paramName.includes('url') || paramName.includes('Url')) {
-						value = expandUrl(value);
+						value = expandUrlQueryValue(value);
 					}
 					stepVars[paramName] = value;
 				}


### PR DESCRIPTION
## Summary
- preserve bare plugin/theme slugs when parsing redirect URL query params
- continue expanding host-like shortened URLs such as github.com/... to https://github.com/...
- add regression coverage for redirect URLs mixing a wordpress.org plugin slug with a GitHub plugin URL

## Tests
- npx vitest run src/frontend/query-params.test.ts
- npx vitest run steps/installPlugin.spec.ts